### PR TITLE
QP-1161: Add pause/resume inventory change event

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,19 +1,14 @@
 const presets = [
   [
-    "@babel/env",
+    '@babel/env',
     {
-      targets: {
-        edge: "17",
-        firefox: "60",
-        chrome: "67",
-        safari: "11.1",
-      },
-      useBuiltIns: "usage",
-    },
-  ],
-];
+      targets: ['>0.2%', 'not dead', 'not ie <= 10', 'not op_mini all'],
+      useBuiltIns: 'usage',
+      corejs: '3'
+    }
+  ]
+]
 
-const plugins = ["@babel/plugin-proposal-class-properties"]
+const plugins = ['@babel/plugin-proposal-class-properties']
 
-module.exports = { presets, plugins };
-
+module.exports = { presets, plugins }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,6 +1204,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+    },
     "core-js-compat": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@io-maana/q-assistant-client",
   "version": "3.2.2-beta",
   "description": "JavaScript package to streamline communication between an assistant and the Maana Q Assistant API.",
-  "main": "build/AssistantAPIClient.js",
+  "main": "build/index.js",
+  "exports": {
+    "./": "./build/"
+  },
   "scripts": {
     "build": "babel src --out-dir build",
     "prepack": "npm run build",
@@ -24,6 +27,7 @@
   },
   "homepage": "https://github.com/maana-io/q-assistant-client#readme",
   "dependencies": {
+    "core-js": "3.6.4",
     "post-robot": "10.0.29"
   },
   "devDependencies": {

--- a/src/AssistantAPIClient.js
+++ b/src/AssistantAPIClient.js
@@ -56,6 +56,19 @@ class AssistantAPIClient {
   }
 
   //
+  // Assistant State
+  //
+
+  /**
+   * Updates the current state of the Assistant.
+   *
+   * @param {AssistantState} state The new state of the assistant.
+   */
+  setAssistantState(state) {
+    return APICall('setAssistantState', state)
+  }
+
+  //
   // State management
   //
   clearState = () => {
@@ -219,21 +232,6 @@ class AssistantAPIClient {
       kindIds,
       functionIds
     })
-  }
-
-  /**
-   * Keeps the Inventory Changed Event from being triggered.
-   */
-  pauseInventoryChangedEvent() {
-    return APICall('pauseInventoryChangedEvent')
-  }
-
-  /**
-   * Starts up triggering the Inventory Changed Event, and will trigger any
-   * changes that happened while it was paused.
-   */
-  resumeInventoryChangedEvent() {
-    return APICall('resumeInventoryChangedEvent')
   }
 
   //

--- a/src/AssistantAPIClient.js
+++ b/src/AssistantAPIClient.js
@@ -44,7 +44,7 @@ class AssistantAPIClient {
       EventEmitter.emit('renderModeChanged', event.data)
     })
 
-    // Attch repair listener.
+    // Attach repair listener.
     createAPIListener('repair', async function(event) {
       // Only create a promise or call the event if there's a subscriber.
       if (EventEmitter._events.repair) {
@@ -219,6 +219,21 @@ class AssistantAPIClient {
       kindIds,
       functionIds
     })
+  }
+
+  /**
+   * Keeps the Inventory Changed Event from being triggered.
+   */
+  pauseInventoryChangedEvent() {
+    return APICall('pauseInventoryChangedEvent')
+  }
+
+  /**
+   * Starts up triggering the Inventory Changed Event, and will trigger any
+   * changes that happened while it was paused.
+   */
+  resumeInventoryChangedEvent() {
+    return APICall('resumeInventoryChangedEvent')
   }
 
   //

--- a/src/AssistantState.js
+++ b/src/AssistantState.js
@@ -1,0 +1,7 @@
+/**
+ * The different states that the assistant can be in.
+ */
+export const AssistantState = Object.freeze({
+  WORKING: 'WORKING',
+  IDLE: 'IDLE'
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+import AssistantAPIClient from './AssistantAPIClient'
+export default AssistantAPIClient
+
+export * from './AssistantState'


### PR DESCRIPTION
This allows the different assistants to pause the inventory changed events when they are making multiple changes to the inventory during a single process.  Examples are Reactor assistant and Import path of Export Import assistant.