### PR TITLE
QP-2263: Move the moving of entities to update worksapce.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@
 
 Ƭ  **EventListenerCallback**: (e: any) => void
 
-*Defined in [AssistantAPIClient.ts:39](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L39)*
+*Defined in [AssistantAPIClient.ts:39](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L39)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 Ƭ  **GraphRef**: [ArgumentRef](interfaces/argumentref.md) \| [OperationArgumentRef](interfaces/operationargumentref.md) \| [FunctionResultRef](interfaces/functionresultref.md) \| [OperationResultRef](interfaces/operationresultref.md) \| [OutputArgumentRef](interfaces/outputargumentref.md)
 
-*Defined in [models.ts:91](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L91)*
+*Defined in [models.ts:91](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L91)*
 
 Info for one end of a connection between two items within the graph.
 
@@ -113,7 +113,7 @@ ___
 
 Ƭ  **Implementation**: [Graph](interfaces/graph.md)
 
-*Defined in [models.ts:255](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L255)*
+*Defined in [models.ts:255](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L255)*
 
 Function implementation union.
 
@@ -123,7 +123,7 @@ ___
 
 Ƭ  **Maybe**\<T>: T \| null \| undefined
 
-*Defined in [models.ts:10](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L10)*
+*Defined in [models.ts:10](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L10)*
 
 #### Type parameters:
 
@@ -137,7 +137,7 @@ ___
 
 Ƭ  **TypeExpressionObject**: any
 
-*Defined in [models.ts:13](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L13)*
+*Defined in [models.ts:13](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L13)*
 
 Represents a JSON object used to express a type expression.
 
@@ -147,6 +147,6 @@ Represents a JSON object used to express a type expression.
 
 • `Const` **CORE\_SERVICE\_ID**: \"io.maana.core\" = "io.maana.core"
 
-*Defined in [constants.ts:20](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L20)*
+*Defined in [constants.ts:20](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L20)*
 
 ID of the io.maana.core service

--- a/docs/enums/assistantstate.md
+++ b/docs/enums/assistantstate.md
@@ -19,7 +19,7 @@ The different states that the assistant can be in.
 
 •  **IDLE**:  = "IDLE"
 
-*Defined in [constants.ts:6](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L6)*
+*Defined in [constants.ts:6](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L6)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 •  **WORKING**:  = "WORKING"
 
-*Defined in [constants.ts:5](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L5)*
+*Defined in [constants.ts:5](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L5)*

--- a/docs/enums/entitytype.md
+++ b/docs/enums/entitytype.md
@@ -30,7 +30,7 @@ from selection or used in graph nodes.
 
 •  **ACTIVITY**:  = "ACTIVITY"
 
-*Defined in [constants.ts:57](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L57)*
+*Defined in [constants.ts:57](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L57)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 •  **CONNECTION**:  = "CONNECTION"
 
-*Defined in [constants.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L53)*
+*Defined in [constants.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L53)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 •  **FILE**:  = "FILE"
 
-*Defined in [constants.ts:44](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L44)*
+*Defined in [constants.ts:44](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L44)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 •  **FUNCTION**:  = "FUNCTION"
 
-*Defined in [constants.ts:45](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L45)*
+*Defined in [constants.ts:45](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L45)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 •  **FUNCTION\_ARGUMENTS**:  = "FUNCTION\_ARGUMENTS"
 
-*Defined in [constants.ts:54](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L54)*
+*Defined in [constants.ts:54](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L54)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 •  **FUNCTION\_OUTPUT**:  = "FUNCTION\_OUTPUT"
 
-*Defined in [constants.ts:55](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L55)*
+*Defined in [constants.ts:55](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L55)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 •  **GRAPH\_NODE**:  = "GRAPH\_NODE"
 
-*Defined in [constants.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L56)*
+*Defined in [constants.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L56)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 •  **KNOWLEDGE\_GRAPH**:  = "KNOWLEDGE\_GRAPH"
 
-*Defined in [constants.ts:46](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L46)*
+*Defined in [constants.ts:46](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L46)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 •  **SERVICE**:  = "SERVICE"
 
-*Defined in [constants.ts:47](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L47)*
+*Defined in [constants.ts:47](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L47)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 •  **TYPE**:  = "TYPE"
 
-*Defined in [constants.ts:48](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L48)*
+*Defined in [constants.ts:48](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L48)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 •  **VALUE**:  = "VALUE"
 
-*Defined in [constants.ts:49](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L49)*
+*Defined in [constants.ts:49](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L49)*
 
 ___
 
@@ -118,4 +118,4 @@ ___
 
 •  **WORKSPACE**:  = "WORKSPACE"
 
-*Defined in [constants.ts:50](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L50)*
+*Defined in [constants.ts:50](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L50)*

--- a/docs/enums/functiontype.md
+++ b/docs/enums/functiontype.md
@@ -19,7 +19,7 @@ The types of a functions.
 
 •  **CKG**:  = "CKG"
 
-*Defined in [constants.ts:75](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L75)*
+*Defined in [constants.ts:75](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L75)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 •  **EXTERNAL**:  = "EXTERNAL"
 
-*Defined in [constants.ts:74](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L74)*
+*Defined in [constants.ts:74](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L74)*

--- a/docs/enums/graphqlfunctiontype.md
+++ b/docs/enums/graphqlfunctiontype.md
@@ -21,7 +21,7 @@ The different GraphQL operations that the function can be used for.
 
 •  **MUTATION**:  = "MUTATION"
 
-*Defined in [constants.ts:83](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L83)*
+*Defined in [constants.ts:83](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L83)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 •  **NONE**:  = "NONE"
 
-*Defined in [constants.ts:85](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L85)*
+*Defined in [constants.ts:85](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L85)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **QUERY**:  = "QUERY"
 
-*Defined in [constants.ts:82](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L82)*
+*Defined in [constants.ts:82](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L82)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 •  **SUBSCRIPTION**:  = "SUBSCRIPTION"
 
-*Defined in [constants.ts:84](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L84)*
+*Defined in [constants.ts:84](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L84)*

--- a/docs/enums/graphrefinputtype.md
+++ b/docs/enums/graphrefinputtype.md
@@ -23,7 +23,7 @@ function graph implementation.
 
 •  **ARGUMENT**:  = "ARGUMENT"
 
-*Defined in [constants.ts:114](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L114)*
+*Defined in [constants.ts:114](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L114)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **FUNCTION\_RESULT**:  = "FUNCTION\_RESULT"
 
-*Defined in [constants.ts:115](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L115)*
+*Defined in [constants.ts:115](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L115)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **OPERATION\_ARGUMENT**:  = "OPERATION\_ARGUMENT"
 
-*Defined in [constants.ts:116](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L116)*
+*Defined in [constants.ts:116](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L116)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 •  **OPERATION\_RESULT**:  = "OPERATION\_RESULT"
 
-*Defined in [constants.ts:117](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L117)*
+*Defined in [constants.ts:117](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L117)*
 
 ___
 
@@ -55,4 +55,4 @@ ___
 
 •  **OUTPUT\_ARGUMENT\_REF**:  = "OUTPUT\_ARGUMENT\_REF"
 
-*Defined in [constants.ts:118](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L118)*
+*Defined in [constants.ts:118](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L118)*

--- a/docs/enums/implementationtype.md
+++ b/docs/enums/implementationtype.md
@@ -18,4 +18,4 @@ The different types implementations that can be used on a CKG function.
 
 •  **FUNCTION\_GRAPH**:  = "FUNCTION\_GRAPH"
 
-*Defined in [constants.ts:92](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L92)*
+*Defined in [constants.ts:92](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L92)*

--- a/docs/enums/nodetype.md
+++ b/docs/enums/nodetype.md
@@ -25,7 +25,7 @@ OPERATION nodes are used to add functions onto the function graph.
 
 •  **ARGUMENT**:  = "ARGUMENT"
 
-*Defined in [constants.ts:104](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L104)*
+*Defined in [constants.ts:104](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L104)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 •  **ENTITY**:  = "ENTITY"
 
-*Defined in [constants.ts:105](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L105)*
+*Defined in [constants.ts:105](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L105)*
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 •  **OPERATION**:  = "OPERATION"
 
-*Defined in [constants.ts:106](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L106)*
+*Defined in [constants.ts:106](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L106)*

--- a/docs/enums/rendermode.md
+++ b/docs/enums/rendermode.md
@@ -19,7 +19,7 @@ The mode in which a custom Assistant should be rendering in.
 
 •  **BACKGROUND**:  = "BACKGROUND"
 
-*Defined in [constants.ts:14](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L14)*
+*Defined in [constants.ts:14](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L14)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 •  **DISPLAY**:  = "DISPLAY"
 
-*Defined in [constants.ts:13](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L13)*
+*Defined in [constants.ts:13](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L13)*

--- a/docs/enums/scalars.md
+++ b/docs/enums/scalars.md
@@ -28,7 +28,7 @@ Names of the default Scalars
 
 •  **BOOLEAN**:  = "Boolean"
 
-*Defined in [constants.ts:30](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L30)*
+*Defined in [constants.ts:30](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L30)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 •  **DATE**:  = "Date"
 
-*Defined in [constants.ts:31](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L31)*
+*Defined in [constants.ts:31](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L31)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 •  **DATETIME**:  = "DateTime"
 
-*Defined in [constants.ts:33](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L33)*
+*Defined in [constants.ts:33](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L33)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 •  **DOUBLE**:  = "Double"
 
-*Defined in [constants.ts:29](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L29)*
+*Defined in [constants.ts:29](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L29)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 •  **FLOAT**:  = "Float"
 
-*Defined in [constants.ts:28](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L28)*
+*Defined in [constants.ts:28](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L28)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 •  **ID**:  = "ID"
 
-*Defined in [constants.ts:35](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L35)*
+*Defined in [constants.ts:35](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L35)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 •  **INT**:  = "Int"
 
-*Defined in [constants.ts:26](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L26)*
+*Defined in [constants.ts:26](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L26)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 •  **JSON**:  = "JSON"
 
-*Defined in [constants.ts:34](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L34)*
+*Defined in [constants.ts:34](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L34)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 •  **LONG**:  = "Long"
 
-*Defined in [constants.ts:27](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L27)*
+*Defined in [constants.ts:27](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L27)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 •  **STRING**:  = "String"
 
-*Defined in [constants.ts:36](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L36)*
+*Defined in [constants.ts:36](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L36)*
 
 ___
 
@@ -108,4 +108,4 @@ ___
 
 •  **TIME**:  = "Time"
 
-*Defined in [constants.ts:32](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L32)*
+*Defined in [constants.ts:32](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L32)*

--- a/docs/enums/servicetype.md
+++ b/docs/enums/servicetype.md
@@ -21,7 +21,7 @@ The different types of possible services
 
 •  **ASSISTANT**:  = "AssistantService"
 
-*Defined in [constants.ts:64](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L64)*
+*Defined in [constants.ts:64](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L64)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 •  **EXTERNAL\_GRAPHQL**:  = "ExternalGraphQLService"
 
-*Defined in [constants.ts:65](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L65)*
+*Defined in [constants.ts:65](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L65)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **LOGIC**:  = "LogicService"
 
-*Defined in [constants.ts:66](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L66)*
+*Defined in [constants.ts:66](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L66)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 •  **MODEL**:  = "ModelService"
 
-*Defined in [constants.ts:67](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/constants.ts#L67)*
+*Defined in [constants.ts:67](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L67)*

--- a/docs/interfaces/argumentfieldselection.md
+++ b/docs/interfaces/argumentfieldselection.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:258](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L258)*
+*Defined in [models.ts:258](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L258)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **fieldSelection**: string[][]
 
-*Defined in [models.ts:259](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L259)*
+*Defined in [models.ts:259](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L259)*

--- a/docs/interfaces/argumentfieldselectioninput.md
+++ b/docs/interfaces/argumentfieldselectioninput.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:700](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L700)*
+*Defined in [models.ts:700](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L700)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • `Optional` **fieldSelection**: [Maybe](../README.md#maybe)\<Array\<Array\<string>>>
 
-*Defined in [models.ts:701](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L701)*
+*Defined in [models.ts:701](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L701)*

--- a/docs/interfaces/argumentref.md
+++ b/docs/interfaces/argumentref.md
@@ -21,7 +21,7 @@
 
 •  **argumentId**: string
 
-*Defined in [models.ts:67](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L67)*
+*Defined in [models.ts:67](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L67)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **argumentName**: string
 
-*Defined in [models.ts:66](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L66)*
+*Defined in [models.ts:66](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L66)*

--- a/docs/interfaces/assistant.md
+++ b/docs/interfaces/assistant.md
@@ -33,7 +33,7 @@
 
 *Inherited from [Entity](entity.md).[description](entity.md#description)*
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -45,7 +45,7 @@ ___
 
 *Inherited from [Entity](entity.md).[id](entity.md#id)*
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -55,7 +55,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:386](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L386)*
+*Defined in [models.ts:386](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L386)*
 
 The location that the Assistant can be reached at.
 
@@ -67,7 +67,7 @@ ___
 
 *Inherited from [Entity](entity.md).[name](entity.md#name)*
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [Entity](entity.md).[nameDescriptor](entity.md#namedescriptor)*
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).
 
@@ -89,7 +89,7 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:392](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L392)*
+*Defined in [models.ts:392](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L392)*
 
 The current version of the Assistant.  This is incremented by catalog each
 time the Assistant is updated.
@@ -100,7 +100,7 @@ time the Assistant is updated.
 
 ▸ **update**(`changes`: [UpdateAssistantInput](updateassistantinput.md)): Promise\<void>
 
-*Defined in [models.ts:398](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L398)*
+*Defined in [models.ts:398](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L398)*
 
 Updates information about the Assistant.
 

--- a/docs/interfaces/cloneentityinput.md
+++ b/docs/interfaces/cloneentityinput.md
@@ -23,7 +23,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:739](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L739)*
+*Defined in [models.ts:739](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L739)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **newName**: string
 
-*Defined in [models.ts:742](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L742)*
+*Defined in [models.ts:742](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L742)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **oldName**: string
 
-*Defined in [models.ts:740](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L740)*
+*Defined in [models.ts:740](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L740)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **oldServiceId**: string
 
-*Defined in [models.ts:741](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L741)*
+*Defined in [models.ts:741](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L741)*

--- a/docs/interfaces/connection.md
+++ b/docs/interfaces/connection.md
@@ -22,7 +22,7 @@
 
 •  **from**: [GraphRef](../README.md#graphref)
 
-*Defined in [models.ts:103](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L103)*
+*Defined in [models.ts:103](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L103)*
 
 End point for the outgoing connection point
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:100](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L100)*
+*Defined in [models.ts:100](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L100)*
 
 ___
 
@@ -40,6 +40,6 @@ ___
 
 •  **to**: [GraphRef](../README.md#graphref)
 
-*Defined in [models.ts:106](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L106)*
+*Defined in [models.ts:106](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L106)*
 
 End point for the incoming connection point

--- a/docs/interfaces/createconnectioninput.md
+++ b/docs/interfaces/createconnectioninput.md
@@ -21,7 +21,7 @@
 
 •  **from**: [GraphRefInput](graphrefinput.md)
 
-*Defined in [models.ts:673](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L673)*
+*Defined in [models.ts:673](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L673)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **to**: [GraphRefInput](graphrefinput.md)
 
-*Defined in [models.ts:674](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L674)*
+*Defined in [models.ts:674](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L674)*

--- a/docs/interfaces/createentityinput.md
+++ b/docs/interfaces/createentityinput.md
@@ -24,7 +24,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:731](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L731)*
+*Defined in [models.ts:731](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L731)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **file**: [Maybe](../README.md#maybe)\<[CreateFileInput](createfileinput.md)>
 
-*Defined in [models.ts:735](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L735)*
+*Defined in [models.ts:735](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L735)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **function**: [Maybe](../README.md#maybe)\<[CreateFunctionInput](createfunctioninput.md)>
 
-*Defined in [models.ts:734](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L734)*
+*Defined in [models.ts:734](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L734)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **knowledgeGraph**: [Maybe](../README.md#maybe)\<[CreateKnowledgeGraphInput](createknowledgegraphinput.md)>
 
-*Defined in [models.ts:732](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L732)*
+*Defined in [models.ts:732](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L732)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **type**: [Maybe](../README.md#maybe)\<[CreateTypeInput](createtypeinput.md)>
 
-*Defined in [models.ts:733](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L733)*
+*Defined in [models.ts:733](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L733)*

--- a/docs/interfaces/createfileinput.md
+++ b/docs/interfaces/createfileinput.md
@@ -30,7 +30,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:719](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L719)*
+*Defined in [models.ts:719](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L719)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:717](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L717)*
+*Defined in [models.ts:717](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L717)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • `Optional` **loadExternalMetadata**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:727](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L727)*
+*Defined in [models.ts:727](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L727)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • `Optional` **mimeType**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:723](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L723)*
+*Defined in [models.ts:723](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L723)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:718](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L718)*
+*Defined in [models.ts:718](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L718)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • `Optional` **progress**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:725](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L725)*
+*Defined in [models.ts:725](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L725)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 •  **serviceId**: string
 
-*Defined in [models.ts:720](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L720)*
+*Defined in [models.ts:720](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L720)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • `Optional` **size**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:724](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L724)*
+*Defined in [models.ts:724](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L724)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • `Optional` **status**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:726](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L726)*
+*Defined in [models.ts:726](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L726)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:722](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L722)*
+*Defined in [models.ts:722](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L722)*
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 •  **url**: string
 
-*Defined in [models.ts:721](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L721)*
+*Defined in [models.ts:721](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L721)*

--- a/docs/interfaces/createfunctioninput.md
+++ b/docs/interfaces/createfunctioninput.md
@@ -28,7 +28,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:707](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L707)*
+*Defined in [models.ts:707](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L707)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • `Optional` **graphImplementation**: [Maybe](../README.md#maybe)\<[CreateGraphInput](creategraphinput.md)>
 
-*Defined in [models.ts:712](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L712)*
+*Defined in [models.ts:712](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L712)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 •  **graphqlFunctionType**: [GraphQLFunctionType](../enums/graphqlfunctiontype.md)
 
-*Defined in [models.ts:710](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L710)*
+*Defined in [models.ts:710](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L710)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:705](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L705)*
+*Defined in [models.ts:705](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L705)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 •  **implementation**: [ImplementationType](../enums/implementationtype.md)
 
-*Defined in [models.ts:711](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L711)*
+*Defined in [models.ts:711](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L711)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • `Optional` **inputMask**: [Maybe](../README.md#maybe)\<Array\<[ArgumentFieldSelectionInput](argumentfieldselectioninput.md)>>
 
-*Defined in [models.ts:713](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L713)*
+*Defined in [models.ts:713](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L713)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • `Optional` **isPure**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:709](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L709)*
+*Defined in [models.ts:709](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L709)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:706](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L706)*
+*Defined in [models.ts:706](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L706)*
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:708](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L708)*
+*Defined in [models.ts:708](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L708)*

--- a/docs/interfaces/creategraphinput.md
+++ b/docs/interfaces/creategraphinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **connections**: [Maybe](../README.md#maybe)\<Array\<[CreateConnectionInput](createconnectioninput.md)>>
 
-*Defined in [models.ts:681](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L681)*
+*Defined in [models.ts:681](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L681)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **nodes**: [Maybe](../README.md#maybe)\<Array\<[CreateNodeInput](createnodeinput.md)>>
 
-*Defined in [models.ts:680](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L680)*
+*Defined in [models.ts:680](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L680)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **offset**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:678](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L678)*
+*Defined in [models.ts:678](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L678)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **zoom**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:679](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L679)*
+*Defined in [models.ts:679](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L679)*

--- a/docs/interfaces/createknowledgegraphinput.md
+++ b/docs/interfaces/createknowledgegraphinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:687](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L687)*
+*Defined in [models.ts:687](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L687)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **graph**: [Maybe](../README.md#maybe)\<[CreateGraphInput](creategraphinput.md)>
 
-*Defined in [models.ts:688](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L688)*
+*Defined in [models.ts:688](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L688)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:685](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L685)*
+*Defined in [models.ts:685](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L685)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:686](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L686)*
+*Defined in [models.ts:686](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L686)*

--- a/docs/interfaces/createnodeinput.md
+++ b/docs/interfaces/createnodeinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:647](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L647)*
+*Defined in [models.ts:647](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L647)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Optional` **entity**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:649](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L649)*
+*Defined in [models.ts:649](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L649)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:644](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L644)*
+*Defined in [models.ts:644](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L644)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isCollapsed**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:646](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L646)*
+*Defined in [models.ts:646](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L646)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:645](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L645)*
+*Defined in [models.ts:645](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L645)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **operation**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:650](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L650)*
+*Defined in [models.ts:650](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L650)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:648](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L648)*
+*Defined in [models.ts:648](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L648)*

--- a/docs/interfaces/createserviceinput.md
+++ b/docs/interfaces/createserviceinput.md
@@ -28,7 +28,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:626](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L626)*
+*Defined in [models.ts:626](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L626)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 •  **endpointUrl**: string
 
-*Defined in [models.ts:627](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L627)*
+*Defined in [models.ts:627](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L627)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:623](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L623)*
+*Defined in [models.ts:623](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L623)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • `Optional` **isReadOnly**: boolean
 
-*Defined in [models.ts:630](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L630)*
+*Defined in [models.ts:630](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L630)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • `Optional` **isSystem**: boolean
 
-*Defined in [models.ts:629](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L629)*
+*Defined in [models.ts:629](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L629)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:625](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L625)*
+*Defined in [models.ts:625](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L625)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 •  **serviceType**: [ServiceType](../enums/servicetype.md)
 
-*Defined in [models.ts:624](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L624)*
+*Defined in [models.ts:624](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L624)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • `Optional` **tags**: Array\<string>
 
-*Defined in [models.ts:631](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L631)*
+*Defined in [models.ts:631](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L631)*
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:628](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L628)*
+*Defined in [models.ts:628](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L628)*

--- a/docs/interfaces/createtypeinput.md
+++ b/docs/interfaces/createtypeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:694](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L694)*
+*Defined in [models.ts:694](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L694)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:692](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L692)*
+*Defined in [models.ts:692](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L692)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isManaged**: boolean
 
-*Defined in [models.ts:696](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L696)*
+*Defined in [models.ts:696](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L696)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:693](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L693)*
+*Defined in [models.ts:693](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L693)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:695](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L695)*
+*Defined in [models.ts:695](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L695)*

--- a/docs/interfaces/createworkspaceinput.md
+++ b/docs/interfaces/createworkspaceinput.md
@@ -30,7 +30,7 @@
 
 • `Optional` **addServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:824](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L824)*
+*Defined in [models.ts:824](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L824)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • `Optional` **createEntities**: [Maybe](../README.md#maybe)\<Array\<[CreateEntityInput](createentityinput.md)>>
 
-*Defined in [models.ts:823](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L823)*
+*Defined in [models.ts:823](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L823)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:817](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L817)*
+*Defined in [models.ts:817](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L817)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:814](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L814)*
+*Defined in [models.ts:814](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L814)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • `Optional` **isPublic**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:821](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L821)*
+*Defined in [models.ts:821](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L821)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • `Optional` **isTemplate**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:822](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L822)*
+*Defined in [models.ts:822](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L822)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:816](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L816)*
+*Defined in [models.ts:816](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L816)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 •  **owner**: string
 
-*Defined in [models.ts:820](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L820)*
+*Defined in [models.ts:820](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L820)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • `Optional` **serviceId**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:815](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L815)*
+*Defined in [models.ts:815](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L815)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:819](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L819)*
+*Defined in [models.ts:819](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L819)*
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:818](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L818)*
+*Defined in [models.ts:818](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L818)*

--- a/docs/interfaces/entity.md
+++ b/docs/interfaces/entity.md
@@ -35,7 +35,7 @@
 
 • `Optional` **description**: string
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -45,7 +45,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -55,7 +55,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -65,6 +65,6 @@ ___
 
 • `Optional` **nameDescriptor**: string
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).

--- a/docs/interfaces/entityidentifier.md
+++ b/docs/interfaces/entityidentifier.md
@@ -23,7 +23,7 @@
 
 •  **entityType**: string
 
-*Defined in [models.ts:34](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L34)*
+*Defined in [models.ts:34](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L34)*
 
 The type of entity being referenced.
 
@@ -33,7 +33,7 @@ ___
 
 • `Optional` **id**: string
 
-*Defined in [models.ts:37](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L37)*
+*Defined in [models.ts:37](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L37)*
 
 The ID of the entity. Used for all but Types and Functions.
 
@@ -43,7 +43,7 @@ ___
 
 • `Optional` **name**: string
 
-*Defined in [models.ts:40](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L40)*
+*Defined in [models.ts:40](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L40)*
 
 The name of the entity. Used by Types and Functions.
 
@@ -53,6 +53,6 @@ ___
 
 • `Optional` **serviceId**: string
 
-*Defined in [models.ts:43](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L43)*
+*Defined in [models.ts:43](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L43)*
 
 The ID of the service that the entity lives in.  Used by Types and Functions.

--- a/docs/interfaces/entitylockinput.md
+++ b/docs/interfaces/entitylockinput.md
@@ -20,4 +20,4 @@
 
 •  **lockedBy**: string
 
-*Defined in [models.ts:635](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L635)*
+*Defined in [models.ts:635](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L635)*

--- a/docs/interfaces/function.md
+++ b/docs/interfaces/function.md
@@ -52,7 +52,7 @@
 
 *Inherited from [Entity](entity.md).[description](entity.md#description)*
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -62,7 +62,7 @@ ___
 
 •  **graphqlFunctionType**: [GraphQLFunctionType](../enums/graphqlfunctiontype.md)
 
-*Defined in [models.ts:281](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L281)*
+*Defined in [models.ts:281](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L281)*
 
 How the function is run (like query or mutation)
 
@@ -74,7 +74,7 @@ ___
 
 *Inherited from [Entity](entity.md).[id](entity.md#id)*
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -84,7 +84,7 @@ ___
 
 •  **implementation**: [Implementation](../README.md#implementation)
 
-*Defined in [models.ts:292](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L292)*
+*Defined in [models.ts:292](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L292)*
 
 The implementation representing what the Function does.  This is only used
 by Functions on Logic services.
@@ -95,7 +95,7 @@ ___
 
 • `Optional` **inputMask**: [ArgumentFieldSelection](argumentfieldselection.md)[]
 
-*Defined in [models.ts:294](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L294)*
+*Defined in [models.ts:294](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L294)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 •  **isPure**: boolean
 
-*Defined in [models.ts:286](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L286)*
+*Defined in [models.ts:286](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L286)*
 
 Defines if this is a pure or impure Function, or if its purity is unknown.
 
@@ -115,7 +115,7 @@ ___
 
 *Inherited from [Entity](entity.md).[name](entity.md#name)*
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [Entity](entity.md).[nameDescriptor](entity.md#namedescriptor)*
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).
 
@@ -137,7 +137,7 @@ ___
 
 •  **service**: [IDObject](idobject.md)
 
-*Defined in [models.ts:275](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L275)*
+*Defined in [models.ts:275](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L275)*
 
 The service that the Kind comes from.
 
@@ -147,7 +147,7 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:272](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L272)*
+*Defined in [models.ts:272](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L272)*
 
 The signature of the Function.
 
@@ -157,7 +157,7 @@ ___
 
 •  **typeParameters**: string[]
 
-*Defined in [models.ts:278](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L278)*
+*Defined in [models.ts:278](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L278)*
 
 Type Parameters are placeholders for types and are used as generics.
 
@@ -167,7 +167,7 @@ Type Parameters are placeholders for types and are used as generics.
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:299](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L299)*
+*Defined in [models.ts:299](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L299)*
 
 Returns boolean stating if the Function is editable.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **execute**(`variables?`: [Maybe](../README.md#maybe)\<Record\<string, any>>, `resolve?`: string): Promise\<any>
 
-*Defined in [models.ts:341](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L341)*
+*Defined in [models.ts:341](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L341)*
 
 Executes a GraphQL request against the Function.
 
@@ -200,7 +200,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:304](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L304)*
+*Defined in [models.ts:304](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L304)*
 
 Returns the e-mail of the user who locked the Function.
 
@@ -212,7 +212,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:311](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L311)*
+*Defined in [models.ts:311](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L311)*
 
 Updates the locked state of the Function.
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)): Promise\<void>
 
-*Defined in [models.ts:317](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L317)*
+*Defined in [models.ts:317](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L317)*
 
 Updates information about the Function.
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **updateGraphLayout**(`changes`: [UpdateGraphLayoutInput](updategraphlayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:333](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L333)*
+*Defined in [models.ts:333](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L333)*
 
 Updates the layout information for the graph of the Function.
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **updateNodeLayout**(`nodeId`: string, `changes`: [UpdateNodeLayoutInput](updatenodelayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:324](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L324)*
+*Defined in [models.ts:324](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L324)*
 
 Updates the layout information for a node in the Function.
 

--- a/docs/interfaces/functionresultref.md
+++ b/docs/interfaces/functionresultref.md
@@ -20,4 +20,4 @@
 
 • `Optional` **result**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:77](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L77)*
+*Defined in [models.ts:77](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L77)*

--- a/docs/interfaces/graph.md
+++ b/docs/interfaces/graph.md
@@ -23,7 +23,7 @@
 
 •  **connections**: [Connection](connection.md)[]
 
-*Defined in [models.ts:145](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L145)*
+*Defined in [models.ts:145](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L145)*
 
 The connections in the Graph.
 
@@ -33,7 +33,7 @@ ___
 
 •  **nodes**: [Node](node.md)[]
 
-*Defined in [models.ts:142](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L142)*
+*Defined in [models.ts:142](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L142)*
 
 The nodes in the Graph.
 
@@ -43,7 +43,7 @@ ___
 
 •  **offset**: [Position](position.md)
 
-*Defined in [models.ts:136](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L136)*
+*Defined in [models.ts:136](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L136)*
 
 The offset of the Graph.
 
@@ -53,6 +53,6 @@ ___
 
 •  **zoom**: number
 
-*Defined in [models.ts:139](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L139)*
+*Defined in [models.ts:139](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L139)*
 
 The zoom of the Graph.

--- a/docs/interfaces/graphrefinput.md
+++ b/docs/interfaces/graphrefinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **argument**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:666](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L666)*
+*Defined in [models.ts:666](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L666)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **graphRefInputType**: [GraphRefInputType](../enums/graphrefinputtype.md)
 
-*Defined in [models.ts:665](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L665)*
+*Defined in [models.ts:665](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L665)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **operationArgument**: [Maybe](../README.md#maybe)\<[OperationArgumentRefInput](operationargumentrefinput.md)>
 
-*Defined in [models.ts:667](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L667)*
+*Defined in [models.ts:667](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L667)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **operationResult**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:668](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L668)*
+*Defined in [models.ts:668](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L668)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **outputArgument**: [Maybe](../README.md#maybe)\<[OutputArgumentRefInput](outputargumentrefinput.md)>
 
-*Defined in [models.ts:669](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L669)*
+*Defined in [models.ts:669](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L669)*

--- a/docs/interfaces/idobject.md
+++ b/docs/interfaces/idobject.md
@@ -20,4 +20,4 @@
 
 •  **id**: string
 
-*Defined in [models.ts:16](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L16)*
+*Defined in [models.ts:16](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L16)*

--- a/docs/interfaces/kind.md
+++ b/docs/interfaces/kind.md
@@ -34,7 +34,7 @@
 
 *Inherited from [Entity](entity.md).[description](entity.md#description)*
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [Entity](entity.md).[id](entity.md#id)*
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -56,7 +56,7 @@ ___
 
 •  **isManaged**: boolean
 
-*Defined in [models.ts:156](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L156)*
+*Defined in [models.ts:156](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L156)*
 
 Used to signify if this type has data that is managed by the platform
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [Entity](entity.md).[name](entity.md#name)*
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [Entity](entity.md).[nameDescriptor](entity.md#namedescriptor)*
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).
 
@@ -90,7 +90,7 @@ ___
 
 •  **service**: [IDObject](idobject.md)
 
-*Defined in [models.ts:153](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L153)*
+*Defined in [models.ts:153](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L153)*
 
 The service that the Kind comes from.
 
@@ -100,7 +100,7 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:150](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L150)*
+*Defined in [models.ts:150](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L150)*
 
 The signature of the Kind.
 
@@ -110,7 +110,7 @@ The signature of the Kind.
 
 ▸ **update**(`changes`: [UpdateTypeInput](updatetypeinput.md)): Promise\<void>
 
-*Defined in [models.ts:162](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L162)*
+*Defined in [models.ts:162](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L162)*
 
 Updates information about the Kind.
 

--- a/docs/interfaces/knowledgegraph.md
+++ b/docs/interfaces/knowledgegraph.md
@@ -55,7 +55,7 @@
 
 *Inherited from [Entity](entity.md).[description](entity.md#description)*
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -65,7 +65,7 @@ ___
 
 •  **graph**: [Graph](graph.md)
 
-*Defined in [models.ts:195](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L195)*
+*Defined in [models.ts:195](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L195)*
 
 The graph information for the Knowledge Graph.
 
@@ -77,7 +77,7 @@ ___
 
 *Inherited from [Entity](entity.md).[id](entity.md#id)*
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -89,7 +89,7 @@ ___
 
 *Inherited from [Entity](entity.md).[name](entity.md#name)*
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [Entity](entity.md).[nameDescriptor](entity.md#namedescriptor)*
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).
 
@@ -111,7 +111,7 @@ ___
 
 •  **offsetX**: number
 
-*Defined in [models.ts:180](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L180)*
+*Defined in [models.ts:180](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L180)*
 
 The X offset of the Knowledge Graph.
 
@@ -123,7 +123,7 @@ ___
 
 •  **offsetY**: number
 
-*Defined in [models.ts:186](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L186)*
+*Defined in [models.ts:186](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L186)*
 
 The Y offset of the Knowledge Graph.
 
@@ -135,7 +135,7 @@ ___
 
 •  **zoom**: number
 
-*Defined in [models.ts:192](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L192)*
+*Defined in [models.ts:192](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L192)*
 
 The zoom of the Knowledge Graph.
 
@@ -147,7 +147,7 @@ The zoom of the Knowledge Graph.
 
 ▸ **addNode**(`entityIdentifier`: [EntityIdentifier](entityidentifier.md)): Promise\<string>
 
-*Defined in [models.ts:226](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L226)*
+*Defined in [models.ts:226](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L226)*
 
 Adds an entity as a node on the Knowledge Graph.
 
@@ -167,7 +167,7 @@ ___
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:198](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L198)*
+*Defined in [models.ts:198](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L198)*
 
 Returns boolean stating if the Knowledge Graph is editable.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **getNodes**(): Promise\<[Node](node.md)[]>
 
-*Defined in [models.ts:220](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L220)*
+*Defined in [models.ts:220](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L220)*
 
 Returns the list of nodes inside of the Knowledge Graph.
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:201](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L201)*
+*Defined in [models.ts:201](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L201)*
 
 Returns the e-mail of the user who locked the Knowledge Graph.
 
@@ -205,7 +205,7 @@ ___
 
 ▸ **removeNode**(`nodeId`: string): Promise\<void>
 
-*Defined in [models.ts:233](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L233)*
+*Defined in [models.ts:233](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L233)*
 
 Removed a node from the Knowledge Graph.
 
@@ -225,7 +225,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:208](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L208)*
+*Defined in [models.ts:208](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L208)*
 
 Updates the locked state of the Knowledge Graph.
 
@@ -243,7 +243,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateKnowledgeGraphInput](updateknowledgegraphinput.md)): Promise\<void>
 
-*Defined in [models.ts:214](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L214)*
+*Defined in [models.ts:214](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L214)*
 
 Updates information about the Knowledge Graph.
 
@@ -261,7 +261,7 @@ ___
 
 ▸ **updateGraphLayout**(`changes`: [UpdateGraphLayoutInput](updategraphlayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:249](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L249)*
+*Defined in [models.ts:249](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L249)*
 
 Updates the layout information for the graph of the Knowledge Graph.
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **updateNodeLayout**(`nodeId`: string, `changes`: [UpdateNodeLayoutInput](updatenodelayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:240](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L240)*
+*Defined in [models.ts:240](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L240)*
 
 Updates the layout information for a node in the Knowledge Graph.
 

--- a/docs/interfaces/node.md
+++ b/docs/interfaces/node.md
@@ -27,7 +27,7 @@ The core shape of a node
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:116](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L116)*
+*Defined in [models.ts:116](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L116)*
 
 Human readable description of the Node.
 
@@ -37,7 +37,7 @@ ___
 
 • `Optional` **entityIdentifier**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:131](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L131)*
+*Defined in [models.ts:131](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L131)*
 
 The entity referenced by the node.
 
@@ -47,7 +47,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:113](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L113)*
+*Defined in [models.ts:113](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L113)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 •  **isCollapsed**: boolean
 
-*Defined in [models.ts:125](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L125)*
+*Defined in [models.ts:125](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L125)*
 
 Indicates if the node is collapsed or expanded in the node display.
 
@@ -65,7 +65,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[Position](position.md)>
 
-*Defined in [models.ts:122](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L122)*
+*Defined in [models.ts:122](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L122)*
 
 Position of the node on the graph. Null indicates the need to layout the
 position.
@@ -76,6 +76,6 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:128](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L128)*
+*Defined in [models.ts:128](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L128)*
 
 The type of node

--- a/docs/interfaces/operationargumentref.md
+++ b/docs/interfaces/operationargumentref.md
@@ -22,7 +22,7 @@
 
 •  **argumentId**: string
 
-*Defined in [models.ts:73](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L73)*
+*Defined in [models.ts:73](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L73)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **argumentName**: string
 
-*Defined in [models.ts:72](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L72)*
+*Defined in [models.ts:72](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L72)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operationId**: string
 
-*Defined in [models.ts:71](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L71)*
+*Defined in [models.ts:71](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L71)*

--- a/docs/interfaces/operationargumentrefinput.md
+++ b/docs/interfaces/operationargumentrefinput.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:655](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L655)*
+*Defined in [models.ts:655](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L655)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:654](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L654)*
+*Defined in [models.ts:654](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L654)*

--- a/docs/interfaces/operationresultref.md
+++ b/docs/interfaces/operationresultref.md
@@ -20,4 +20,4 @@
 
 •  **operationId**: string
 
-*Defined in [models.ts:81](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L81)*
+*Defined in [models.ts:81](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L81)*

--- a/docs/interfaces/outputargumentref.md
+++ b/docs/interfaces/outputargumentref.md
@@ -22,7 +22,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:87](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L87)*
+*Defined in [models.ts:87](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L87)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **fieldPath**: string[]
 
-*Defined in [models.ts:86](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L86)*
+*Defined in [models.ts:86](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L86)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:85](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L85)*
+*Defined in [models.ts:85](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L85)*

--- a/docs/interfaces/outputargumentrefinput.md
+++ b/docs/interfaces/outputargumentrefinput.md
@@ -22,7 +22,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:661](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L661)*
+*Defined in [models.ts:661](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L661)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **fieldPath**: Array\<string>
 
-*Defined in [models.ts:660](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L660)*
+*Defined in [models.ts:660](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L660)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:659](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L659)*
+*Defined in [models.ts:659](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L659)*

--- a/docs/interfaces/position.md
+++ b/docs/interfaces/position.md
@@ -21,7 +21,7 @@
 
 •  **x**: number
 
-*Defined in [models.ts:20](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L20)*
+*Defined in [models.ts:20](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L20)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **y**: number
 
-*Defined in [models.ts:21](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L21)*
+*Defined in [models.ts:21](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L21)*

--- a/docs/interfaces/positioninput.md
+++ b/docs/interfaces/positioninput.md
@@ -21,7 +21,7 @@
 
 • `Optional` **x**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:639](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L639)*
+*Defined in [models.ts:639](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L639)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • `Optional` **y**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:640](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L640)*
+*Defined in [models.ts:640](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L640)*

--- a/docs/interfaces/selected.md
+++ b/docs/interfaces/selected.md
@@ -20,6 +20,6 @@
 
 •  **selection**: [EntityIdentifier](entityidentifier.md)[]
 
-*Defined in [models.ts:48](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L48)*
+*Defined in [models.ts:48](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L48)*
 
 The list of selected entities.

--- a/docs/interfaces/service.md
+++ b/docs/interfaces/service.md
@@ -36,7 +36,7 @@
 
 *Inherited from [Entity](entity.md).[description](entity.md#description)*
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -48,7 +48,7 @@ ___
 
 *Inherited from [Entity](entity.md).[id](entity.md#id)*
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -58,7 +58,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:360](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L360)*
+*Defined in [models.ts:360](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L360)*
 
 The location that the service can be reached at.
 
@@ -70,7 +70,7 @@ ___
 
 *Inherited from [Entity](entity.md).[name](entity.md#name)*
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [Entity](entity.md).[nameDescriptor](entity.md#namedescriptor)*
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).
 
@@ -92,7 +92,7 @@ ___
 
 •  **type**: [ServiceType](../enums/servicetype.md)
 
-*Defined in [models.ts:369](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L369)*
+*Defined in [models.ts:369](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L369)*
 
 The type of the service.
 
@@ -102,7 +102,7 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:366](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L366)*
+*Defined in [models.ts:366](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L366)*
 
 The current version of the Service.  This is incremented by catalog each
 time the service is updated.
@@ -113,7 +113,7 @@ time the service is updated.
 
 ▸ **getFunctions**(): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:375](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L375)*
+*Defined in [models.ts:375](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L375)*
 
 Retrieves the list of Function that are part of the Service.
 
@@ -125,7 +125,7 @@ ___
 
 ▸ **getKinds**(): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:372](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L372)*
+*Defined in [models.ts:372](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L372)*
 
 Retrieves the list of Kinds that are part of the Service.
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateExternalGraphQLServiceInput](updateexternalgraphqlserviceinput.md)): Promise\<void>
 
-*Defined in [models.ts:381](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L381)*
+*Defined in [models.ts:381](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L381)*
 
 Updates information about the Service.
 

--- a/docs/interfaces/servicelocation.md
+++ b/docs/interfaces/servicelocation.md
@@ -21,7 +21,7 @@
 
 •  **platformUrl**: string
 
-*Defined in [models.ts:355](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L355)*
+*Defined in [models.ts:355](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L355)*
 
 A form of the URL that uses the Maana Q platform to proxy a request to the
 service. This is useful if the client cannot directly access the service.
@@ -32,6 +32,6 @@ ___
 
 •  **url**: string
 
-*Defined in [models.ts:349](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L349)*
+*Defined in [models.ts:349](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L349)*
 
 The URL that the locator references.

--- a/docs/interfaces/updateassistantinput.md
+++ b/docs/interfaces/updateassistantinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **endpointUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:615](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L615)*
+*Defined in [models.ts:615](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L615)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:613](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L613)*
+*Defined in [models.ts:613](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L613)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **isReadOnly**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:617](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L617)*
+*Defined in [models.ts:617](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L617)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isSystem**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:616](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L616)*
+*Defined in [models.ts:616](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L616)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:614](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L614)*
+*Defined in [models.ts:614](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L614)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:618](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L618)*
+*Defined in [models.ts:618](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L618)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:619](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L619)*
+*Defined in [models.ts:619](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L619)*

--- a/docs/interfaces/updateentityinput.md
+++ b/docs/interfaces/updateentityinput.md
@@ -24,7 +24,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:806](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L806)*
+*Defined in [models.ts:806](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L806)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **file**: [Maybe](../README.md#maybe)\<[UpdateFileInput](updatefileinput.md)>
 
-*Defined in [models.ts:810](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L810)*
+*Defined in [models.ts:810](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L810)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **function**: [Maybe](../README.md#maybe)\<[UpdateFunctionInput](updatefunctioninput.md)>
 
-*Defined in [models.ts:809](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L809)*
+*Defined in [models.ts:809](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L809)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **knowledgeGraph**: [Maybe](../README.md#maybe)\<[UpdateKnowledgeGraphInput](updateknowledgegraphinput.md)>
 
-*Defined in [models.ts:807](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L807)*
+*Defined in [models.ts:807](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L807)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **type**: [Maybe](../README.md#maybe)\<[UpdateTypeInput](updatetypeinput.md)>
 
-*Defined in [models.ts:808](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L808)*
+*Defined in [models.ts:808](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L808)*

--- a/docs/interfaces/updateexternalgraphqlserviceinput.md
+++ b/docs/interfaces/updateexternalgraphqlserviceinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **endpointUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:605](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L605)*
+*Defined in [models.ts:605](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L605)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:603](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L603)*
+*Defined in [models.ts:603](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L603)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **isReadOnly**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:607](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L607)*
+*Defined in [models.ts:607](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L607)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isSystem**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:606](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L606)*
+*Defined in [models.ts:606](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L606)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:604](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L604)*
+*Defined in [models.ts:604](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L604)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:608](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L608)*
+*Defined in [models.ts:608](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L608)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:609](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L609)*
+*Defined in [models.ts:609](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L609)*

--- a/docs/interfaces/updatefileinput.md
+++ b/docs/interfaces/updatefileinput.md
@@ -29,7 +29,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:795](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L795)*
+*Defined in [models.ts:795](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L795)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:793](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L793)*
+*Defined in [models.ts:793](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L793)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • `Optional` **mimeType**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:799](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L799)*
+*Defined in [models.ts:799](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L799)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:794](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L794)*
+*Defined in [models.ts:794](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L794)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • `Optional` **progress**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:801](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L801)*
+*Defined in [models.ts:801](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L801)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • `Optional` **serviceId**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:796](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L796)*
+*Defined in [models.ts:796](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L796)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • `Optional` **size**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:800](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L800)*
+*Defined in [models.ts:800](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L800)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • `Optional` **status**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:802](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L802)*
+*Defined in [models.ts:802](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L802)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:798](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L798)*
+*Defined in [models.ts:798](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L798)*
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • `Optional` **url**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:797](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L797)*
+*Defined in [models.ts:797](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L797)*

--- a/docs/interfaces/updatefunctioninput.md
+++ b/docs/interfaces/updatefunctioninput.md
@@ -29,7 +29,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:782](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L782)*
+*Defined in [models.ts:782](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L782)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • `Optional` **graphImplementation**: [Maybe](../README.md#maybe)\<[UpdateGraphInput](updategraphinput.md)>
 
-*Defined in [models.ts:788](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L788)*
+*Defined in [models.ts:788](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L788)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • `Optional` **graphqlFunctionType**: [Maybe](../README.md#maybe)\<[GraphQLFunctionType](../enums/graphqlfunctiontype.md)>
 
-*Defined in [models.ts:785](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L785)*
+*Defined in [models.ts:785](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L785)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:780](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L780)*
+*Defined in [models.ts:780](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L780)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • `Optional` **implementation**: [Maybe](../README.md#maybe)\<[ImplementationType](../enums/implementationtype.md)>
 
-*Defined in [models.ts:787](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L787)*
+*Defined in [models.ts:787](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L787)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • `Optional` **inputMask**: [Maybe](../README.md#maybe)\<Array\<[ArgumentFieldSelectionInput](argumentfieldselectioninput.md)>>
 
-*Defined in [models.ts:789](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L789)*
+*Defined in [models.ts:789](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L789)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • `Optional` **isPure**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:784](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L784)*
+*Defined in [models.ts:784](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L784)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:786](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L786)*
+*Defined in [models.ts:786](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L786)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:781](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L781)*
+*Defined in [models.ts:781](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L781)*
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • `Optional` **signature**: [Maybe](../README.md#maybe)\<[TypeExpressionObject](../README.md#typeexpressionobject)>
 
-*Defined in [models.ts:783](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L783)*
+*Defined in [models.ts:783](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L783)*

--- a/docs/interfaces/updategraphinput.md
+++ b/docs/interfaces/updategraphinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **createConnections**: [Maybe](../README.md#maybe)\<Array\<[CreateConnectionInput](createconnectioninput.md)>>
 
-*Defined in [models.ts:759](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L759)*
+*Defined in [models.ts:759](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L759)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Optional` **createNodes**: [Maybe](../README.md#maybe)\<Array\<[CreateNodeInput](createnodeinput.md)>>
 
-*Defined in [models.ts:756](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L756)*
+*Defined in [models.ts:756](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L756)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **deleteConnections**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:760](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L760)*
+*Defined in [models.ts:760](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L760)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **deleteNodes**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:758](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L758)*
+*Defined in [models.ts:758](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L758)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **offset**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:754](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L754)*
+*Defined in [models.ts:754](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L754)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **updateNodes**: [Maybe](../README.md#maybe)\<Array\<[UpdateNodeInput](updatenodeinput.md)>>
 
-*Defined in [models.ts:757](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L757)*
+*Defined in [models.ts:757](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L757)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 • `Optional` **zoom**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:755](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L755)*
+*Defined in [models.ts:755](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L755)*

--- a/docs/interfaces/updategraphlayoutinput.md
+++ b/docs/interfaces/updategraphlayoutinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **nodes**: [UpdateNodeLayoutInput](updatenodelayoutinput.md) & { id: string  }[]
 
-*Defined in [models.ts:599](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L599)*
+*Defined in [models.ts:599](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L599)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **offsetX**: number
 
-*Defined in [models.ts:597](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L597)*
+*Defined in [models.ts:597](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L597)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **offsetY**: number
 
-*Defined in [models.ts:598](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L598)*
+*Defined in [models.ts:598](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L598)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **zoom**: number
 
-*Defined in [models.ts:596](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L596)*
+*Defined in [models.ts:596](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L596)*

--- a/docs/interfaces/updateknowledgegraphinput.md
+++ b/docs/interfaces/updateknowledgegraphinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:766](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L766)*
+*Defined in [models.ts:766](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L766)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **graph**: [Maybe](../README.md#maybe)\<[UpdateGraphInput](updategraphinput.md)>
 
-*Defined in [models.ts:768](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L768)*
+*Defined in [models.ts:768](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L768)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:764](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L764)*
+*Defined in [models.ts:764](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L764)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:767](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L767)*
+*Defined in [models.ts:767](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L767)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:765](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L765)*
+*Defined in [models.ts:765](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L765)*

--- a/docs/interfaces/updatenodeinput.md
+++ b/docs/interfaces/updatenodeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:749](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L749)*
+*Defined in [models.ts:749](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L749)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:746](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L746)*
+*Defined in [models.ts:746](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L746)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isCollapsed**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:748](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L748)*
+*Defined in [models.ts:748](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L748)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:747](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L747)*
+*Defined in [models.ts:747](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L747)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:750](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L750)*
+*Defined in [models.ts:750](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L750)*

--- a/docs/interfaces/updatenodelayoutinput.md
+++ b/docs/interfaces/updatenodelayoutinput.md
@@ -22,7 +22,7 @@
 
 • `Optional` **collapsed**: boolean
 
-*Defined in [models.ts:592](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L592)*
+*Defined in [models.ts:592](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L592)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • `Optional` **x**: number
 
-*Defined in [models.ts:590](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L590)*
+*Defined in [models.ts:590](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L590)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • `Optional` **y**: number
 
-*Defined in [models.ts:591](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L591)*
+*Defined in [models.ts:591](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L591)*

--- a/docs/interfaces/updatetypeinput.md
+++ b/docs/interfaces/updatetypeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:774](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L774)*
+*Defined in [models.ts:774](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L774)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:772](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L772)*
+*Defined in [models.ts:772](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L772)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isManaged**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:776](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L776)*
+*Defined in [models.ts:776](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L776)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:773](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L773)*
+*Defined in [models.ts:773](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L773)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **signature**: [Maybe](../README.md#maybe)\<[TypeExpressionObject](../README.md#typeexpressionobject)>
 
-*Defined in [models.ts:775](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L775)*
+*Defined in [models.ts:775](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L775)*

--- a/docs/interfaces/updateworkspaceinput.md
+++ b/docs/interfaces/updateworkspaceinput.md
@@ -21,6 +21,7 @@
 * [isPublic](updateworkspaceinput.md#ispublic)
 * [isTemplate](updateworkspaceinput.md#istemplate)
 * [lock](updateworkspaceinput.md#lock)
+* [moveEntities](updateworkspaceinput.md#moveentities)
 * [name](updateworkspaceinput.md#name)
 * [removeServices](updateworkspaceinput.md#removeservices)
 * [tags](updateworkspaceinput.md#tags)
@@ -33,7 +34,7 @@
 
 • `Optional` **addServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:840](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L840)*
+*Defined in [models.ts:847](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L847)*
 
 ___
 
@@ -41,7 +42,7 @@ ___
 
 • `Optional` **cloneEntities**: [Maybe](../README.md#maybe)\<Array\<[CloneEntityInput](cloneentityinput.md)>>
 
-*Defined in [models.ts:837](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L837)*
+*Defined in [models.ts:837](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L837)*
 
 ___
 
@@ -49,7 +50,7 @@ ___
 
 • `Optional` **createEntities**: [Maybe](../README.md#maybe)\<Array\<[CreateEntityInput](createentityinput.md)>>
 
-*Defined in [models.ts:836](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L836)*
+*Defined in [models.ts:836](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L836)*
 
 ___
 
@@ -57,7 +58,7 @@ ___
 
 • `Optional` **deleteEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:839](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L839)*
+*Defined in [models.ts:846](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L846)*
 
 ___
 
@@ -65,7 +66,7 @@ ___
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:830](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L830)*
+*Defined in [models.ts:830](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L830)*
 
 ___
 
@@ -73,7 +74,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:828](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L828)*
+*Defined in [models.ts:828](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L828)*
 
 ___
 
@@ -81,7 +82,7 @@ ___
 
 • `Optional` **isPublic**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:833](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L833)*
+*Defined in [models.ts:833](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L833)*
 
 ___
 
@@ -89,7 +90,7 @@ ___
 
 • `Optional` **isTemplate**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:834](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L834)*
+*Defined in [models.ts:834](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L834)*
 
 ___
 
@@ -97,7 +98,18 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:835](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L835)*
+*Defined in [models.ts:835](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L835)*
+
+___
+
+### moveEntities
+
+• `Optional` **moveEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
+
+*Defined in [models.ts:844](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L844)*
+
+Moves the given entities from their current Workspace to this one.
+Currently only Types and Functions support being moved between Workspaces.
 
 ___
 
@@ -105,7 +117,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:829](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L829)*
+*Defined in [models.ts:829](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L829)*
 
 ___
 
@@ -113,7 +125,7 @@ ___
 
 • `Optional` **removeServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:841](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L841)*
+*Defined in [models.ts:848](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L848)*
 
 ___
 
@@ -121,7 +133,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:832](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L832)*
+*Defined in [models.ts:832](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L832)*
 
 ___
 
@@ -129,7 +141,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:831](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L831)*
+*Defined in [models.ts:831](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L831)*
 
 ___
 
@@ -137,4 +149,4 @@ ___
 
 • `Optional` **updateEntities**: [Maybe](../README.md#maybe)\<Array\<[UpdateEntityInput](updateentityinput.md)>>
 
-*Defined in [models.ts:838](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L838)*
+*Defined in [models.ts:838](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L838)*

--- a/docs/interfaces/user.md
+++ b/docs/interfaces/user.md
@@ -21,7 +21,7 @@
 
 •  **email**: string
 
-*Defined in [models.ts:26](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L26)*
+*Defined in [models.ts:26](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L26)*
 
 The users email address.
 
@@ -31,6 +31,6 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:29](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L29)*
+*Defined in [models.ts:29](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L29)*
 
 The users name.

--- a/docs/interfaces/workspace.md
+++ b/docs/interfaces/workspace.md
@@ -69,7 +69,7 @@
 
 *Inherited from [Entity](entity.md).[description](entity.md#description)*
 
-*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L62)*
+*Defined in [models.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L62)*
 
 Human readable description of the entity.
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [Entity](entity.md).[id](entity.md#id)*
 
-*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L53)*
+*Defined in [models.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L53)*
 
 The ID of the entity.
 
@@ -91,7 +91,7 @@ ___
 
 •  **isPublic**: boolean
 
-*Defined in [models.ts:415](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L415)*
+*Defined in [models.ts:415](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L415)*
 
 When true others can see this Workspace.
 
@@ -101,7 +101,7 @@ ___
 
 •  **isTemplate**: boolean
 
-*Defined in [models.ts:418](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L418)*
+*Defined in [models.ts:418](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L418)*
 
 When true it shows up as a template Workspace.
 
@@ -111,7 +111,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:403](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L403)*
+*Defined in [models.ts:403](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L403)*
 
 The location information about the Workspace.
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [Entity](entity.md).[name](entity.md#name)*
 
-*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L56)*
+*Defined in [models.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L56)*
 
 The name of the entity.
 
@@ -135,7 +135,7 @@ ___
 
 *Inherited from [Entity](entity.md).[nameDescriptor](entity.md#namedescriptor)*
 
-*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L59)*
+*Defined in [models.ts:59](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L59)*
 
 Name of where the entity comes from (Service/Workspace).
 
@@ -145,7 +145,7 @@ ___
 
 •  **owner**: { id: string ; name: string  }
 
-*Defined in [models.ts:424](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L424)*
+*Defined in [models.ts:424](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L424)*
 
 The user that owns the Workspace.
 
@@ -162,7 +162,7 @@ ___
 
 •  **persistenceServiceId**: string
 
-*Defined in [models.ts:412](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L412)*
+*Defined in [models.ts:412](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L412)*
 
 The ID of the model service handling persistence for the Workspace
 
@@ -172,7 +172,7 @@ ___
 
 •  **serviceId**: string
 
-*Defined in [models.ts:409](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L409)*
+*Defined in [models.ts:409](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L409)*
 
 The ID of the logic service backing the Workspace.
 
@@ -182,7 +182,7 @@ ___
 
 •  **tags**: string[]
 
-*Defined in [models.ts:421](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L421)*
+*Defined in [models.ts:421](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L421)*
 
 The list of tags for the Workspace.
 
@@ -192,7 +192,7 @@ ___
 
 •  **thumbnailUrl**: string
 
-*Defined in [models.ts:406](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L406)*
+*Defined in [models.ts:406](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L406)*
 
 The URL to the URL of the thumbnail pic.
 
@@ -202,7 +202,7 @@ The URL to the URL of the thumbnail pic.
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:427](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L427)*
+*Defined in [models.ts:427](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L427)*
 
 Returns boolean stating if the Workspace is editable.
 
@@ -214,7 +214,7 @@ ___
 
 ▸ **createFunction**(`input`: [CreateFunctionInput](createfunctioninput.md)): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:514](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L514)*
+*Defined in [models.ts:514](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L514)*
 
 Creates a new Function in the Workspace.
 
@@ -232,7 +232,7 @@ ___
 
 ▸ **createFunctions**(`input`: [CreateFunctionInput](createfunctioninput.md)[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:520](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L520)*
+*Defined in [models.ts:520](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L520)*
 
 Creates a list of new Functions in the Workspace.
 
@@ -250,7 +250,7 @@ ___
 
 ▸ **createKind**(`input`: [CreateTypeInput](createtypeinput.md)): Promise\<[Kind](kind.md)>
 
-*Defined in [models.ts:562](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L562)*
+*Defined in [models.ts:562](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L562)*
 
 Creates a new Kind in the Workspace.
 
@@ -268,7 +268,7 @@ ___
 
 ▸ **createKinds**(`input`: [CreateTypeInput](createtypeinput.md)[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:568](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L568)*
+*Defined in [models.ts:568](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L568)*
 
 Creates a list of Kinds in the Workspace.
 
@@ -286,7 +286,7 @@ ___
 
 ▸ **createKnowledgeGraph**(`input`: [CreateKnowledgeGraphInput](createknowledgegraphinput.md)): Promise\<void>
 
-*Defined in [models.ts:461](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L461)*
+*Defined in [models.ts:461](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L461)*
 
 Creates a new Knowledge Graph in the Workspace.
 
@@ -304,7 +304,7 @@ ___
 
 ▸ **createKnowledgeGraphs**(`input`: [CreateKnowledgeGraphInput](createknowledgegraphinput.md)[]): Promise\<void>
 
-*Defined in [models.ts:467](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L467)*
+*Defined in [models.ts:467](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L467)*
 
 Creates a list of new Knowledge Graphs in the Workspace.
 
@@ -322,7 +322,7 @@ ___
 
 ▸ **deleteFunction**(`name`: string): Promise\<void>
 
-*Defined in [models.ts:538](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L538)*
+*Defined in [models.ts:538](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L538)*
 
 Deletes a function in the Workspace.
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **deleteKind**(`name`: string): Promise\<void>
 
-*Defined in [models.ts:586](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L586)*
+*Defined in [models.ts:586](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L586)*
 
 Deletes a Kind in the Workspace.
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **getActiveGraph**(): Promise\<[Maybe](../README.md#maybe)\<[KnowledgeGraph](knowledgegraph.md) \| [Function](function.md)>>
 
-*Defined in [models.ts:452](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L452)*
+*Defined in [models.ts:452](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L452)*
 
 Gets the currently active graph.
 
@@ -370,7 +370,7 @@ ___
 
 ▸ **getFunctionGraph**(`id`: string): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:547](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L547)*
+*Defined in [models.ts:547](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L547)*
 
 Gets the Function based on ID with its implementation and graph
 information.
@@ -392,7 +392,7 @@ ___
 
 ▸ **getFunctions**(): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:502](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L502)*
+*Defined in [models.ts:502](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L502)*
 
 Gets the list of Functions that live in the Workspace.
 
@@ -404,7 +404,7 @@ ___
 
 ▸ **getFunctionsByName**(`names`: string[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:508](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L508)*
+*Defined in [models.ts:508](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L508)*
 
 Gets a list of Functions that live in the Workspace based on their names.
 
@@ -422,7 +422,7 @@ ___
 
 ▸ **getImportedAssistants**(): Promise\<[Assistant](assistant.md)[]>
 
-*Defined in [models.ts:473](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L473)*
+*Defined in [models.ts:473](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L473)*
 
 Gets all of the Assistants imported into the Workspaces inventory.
 
@@ -434,7 +434,7 @@ ___
 
 ▸ **getImportedServices**(): Promise\<[Service](service.md)[]>
 
-*Defined in [models.ts:470](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L470)*
+*Defined in [models.ts:470](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L470)*
 
 Gets all of the Services imported into the Workspaces inventory.
 
@@ -446,7 +446,7 @@ ___
 
 ▸ **getKinds**(): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:550](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L550)*
+*Defined in [models.ts:550](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L550)*
 
 Gets the list of Kinds that live in the Workspace.
 
@@ -458,7 +458,7 @@ ___
 
 ▸ **getKindsByName**(`names`: string[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:556](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L556)*
+*Defined in [models.ts:556](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L556)*
 
 Gets a list of Kinds that live in the Workspace based on their names.
 
@@ -476,7 +476,7 @@ ___
 
 ▸ **getKnowledgeGraphs**(): Promise\<[KnowledgeGraph](knowledgegraph.md)[]>
 
-*Defined in [models.ts:455](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L455)*
+*Defined in [models.ts:455](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L455)*
 
 Gets all of the Knowledge Graphs in the Workspace.
 
@@ -488,7 +488,7 @@ ___
 
 ▸ **importService**(`serviceId`: string): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:480](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L480)*
+*Defined in [models.ts:480](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L480)*
 
 Imports a Service or Assistant into the Workspaces inventory.
 
@@ -508,7 +508,7 @@ ___
 
 ▸ **importServices**(`serviceIds`: string[]): Promise\<string[]>
 
-*Defined in [models.ts:487](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L487)*
+*Defined in [models.ts:487](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L487)*
 
 Imports a list of Services and/or Assistants into the Workspaces inventory.
 
@@ -528,7 +528,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:430](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L430)*
+*Defined in [models.ts:430](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L430)*
 
 Returns the e-mail of the user who locked the Workspace.
 
@@ -540,7 +540,7 @@ ___
 
 ▸ **reload**(): Promise\<[Workspace](workspace.md)>
 
-*Defined in [models.ts:446](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L446)*
+*Defined in [models.ts:446](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L446)*
 
 Returns a new copy of the workspace with reloaded information.
 
@@ -552,7 +552,7 @@ ___
 
 ▸ **removeService**(`serviceId`: string): Promise\<void>
 
-*Defined in [models.ts:493](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L493)*
+*Defined in [models.ts:493](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L493)*
 
 Removes a Service or Assistant from the Workspaces inventory.
 
@@ -570,7 +570,7 @@ ___
 
 ▸ **removeServices**(`serviceIds`: string): Promise\<void>
 
-*Defined in [models.ts:499](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L499)*
+*Defined in [models.ts:499](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L499)*
 
 Removes a list Services and/or Assistants from the Workspaces inventory.
 
@@ -588,7 +588,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:437](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L437)*
+*Defined in [models.ts:437](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L437)*
 
 Updates the locked state of the Workspace.
 
@@ -606,7 +606,7 @@ ___
 
 ▸ **triggerRepairEvent**(): Promise\<void>
 
-*Defined in [models.ts:449](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L449)*
+*Defined in [models.ts:449](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L449)*
 
 Sends a repair event to all assistants.
 
@@ -618,7 +618,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateWorkspaceInput](updateworkspaceinput.md)): Promise\<void>
 
-*Defined in [models.ts:443](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L443)*
+*Defined in [models.ts:443](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L443)*
 
 Updates information about the Workspace.
 
@@ -636,7 +636,7 @@ ___
 
 ▸ **updateFunction**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:526](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L526)*
+*Defined in [models.ts:526](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L526)*
 
 Updates a Function in the Workspace.
 
@@ -654,7 +654,7 @@ ___
 
 ▸ **updateFunctions**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:532](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L532)*
+*Defined in [models.ts:532](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L532)*
 
 Updates a list of Function in the Workspace.
 
@@ -672,7 +672,7 @@ ___
 
 ▸ **updateKind**(`changes`: [UpdateTypeInput](updatetypeinput.md)): Promise\<[Kind](kind.md)>
 
-*Defined in [models.ts:574](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L574)*
+*Defined in [models.ts:574](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L574)*
 
 Updates a Kind in the Workspace.
 
@@ -690,7 +690,7 @@ ___
 
 ▸ **updateKinds**(`changes`: [UpdateTypeInput](updatetypeinput.md)[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:580](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/models.ts#L580)*
+*Defined in [models.ts:580](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L580)*
 
 Updates a list of Kinds in the Workspace.
 

--- a/docs/modules/assistantapiclient.md
+++ b/docs/modules/assistantapiclient.md
@@ -60,7 +60,7 @@
 
 ▸ **addFunctionExecutionListener**(`id`: string, `cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:451](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L451)*
+*Defined in [AssistantAPIClient.ts:451](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L451)*
 
 Adds a callback function to be called with the function has been executed.
 
@@ -79,7 +79,7 @@ ___
 
 ▸ **addInventoryChangedListener**(`cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:609](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L609)*
+*Defined in [AssistantAPIClient.ts:609](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L609)*
 
 Adds a listener for the inventory changed event.
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **addLockingChangedListener**(`cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:769](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L769)*
+*Defined in [AssistantAPIClient.ts:769](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L769)*
 
 Adds a callback function to be called every time the locking changed event
 is triggered.
@@ -116,7 +116,7 @@ ___
 
 ▸ **addRenderModeChangedListener**(`cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:684](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L684)*
+*Defined in [AssistantAPIClient.ts:684](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L684)*
 
 Adds a listener to the render mode changed event.
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **addRepairListener**(`cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:726](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L726)*
+*Defined in [AssistantAPIClient.ts:726](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L726)*
 
 Adds a listener to the repair changed event.
 
@@ -154,7 +154,7 @@ ___
 
 ▸ **addSelectionChangedListener**(`cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:166](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L166)*
+*Defined in [AssistantAPIClient.ts:166](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L166)*
 
 Adds a listener to the selection changed event.
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **clearState**(): void
 
-*Defined in [AssistantAPIClient.ts:140](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L140)*
+*Defined in [AssistantAPIClient.ts:140](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L140)*
 
 Removes all event listeners for all events.
 
@@ -184,7 +184,7 @@ ___
 
 ▸ **createFunction**(`input`: [CreateFunctionInput](../interfaces/createfunctioninput.md)): Promise\<[Function](../interfaces/function.md)>
 
-*Defined in [AssistantAPIClient.ts:351](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L351)*
+*Defined in [AssistantAPIClient.ts:351](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L351)*
 
 Creates a new function with the supplied information.  At minimum a name
 needs to be supplied.
@@ -208,7 +208,7 @@ ___
 
 ▸ **createKind**(`input`: [CreateTypeInput](../interfaces/createtypeinput.md)): Promise\<[Kind](../interfaces/kind.md)>
 
-*Defined in [AssistantAPIClient.ts:492](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L492)*
+*Defined in [AssistantAPIClient.ts:492](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L492)*
 
 Creates a new Kind with the supplied information.  At minimum a name needs
 to be supplied.
@@ -232,7 +232,7 @@ ___
 
 ▸ **createService**(`input`: [CreateServiceInput](../interfaces/createserviceinput.md)): Promise\<string>
 
-*Defined in [AssistantAPIClient.ts:216](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L216)*
+*Defined in [AssistantAPIClient.ts:216](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L216)*
 
 Creates a new Service in the platform.
 
@@ -252,7 +252,7 @@ ___
 
 ▸ **createWorkspace**(`workspace`: [CreateWorkspaceInput](../interfaces/createworkspaceinput.md)): Promise\<[Workspace](../interfaces/workspace.md)>
 
-*Defined in [AssistantAPIClient.ts:311](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L311)*
+*Defined in [AssistantAPIClient.ts:311](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L311)*
 
 Creates a new Workspace.  The id, name, and serviceId can optionally be
 set, or they can be left undefined to use the defaults.
@@ -273,7 +273,7 @@ ___
 
 ▸ **deleteFunction**(`input`: string): Promise\<void>
 
-*Defined in [AssistantAPIClient.ts:381](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L381)*
+*Defined in [AssistantAPIClient.ts:381](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L381)*
 
 Deletes a function in the active workspace by the given name.
 
@@ -294,7 +294,7 @@ ___
 
 ▸ **deleteKind**(`input`: string): Promise\<void>
 
-*Defined in [AssistantAPIClient.ts:518](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L518)*
+*Defined in [AssistantAPIClient.ts:518](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L518)*
 
 Deletes a Kind in the active workspace by the given name.
 
@@ -315,7 +315,7 @@ ___
 
 ▸ **deleteService**(`id`: string): Promise\<void>
 
-*Defined in [AssistantAPIClient.ts:250](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L250)*
+*Defined in [AssistantAPIClient.ts:250](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L250)*
 
 Deletes the given Service from the platform.
 
@@ -333,7 +333,7 @@ ___
 
 ▸ **executeFunction**(`input`: { entityIdentifier: [EntityIdentifier](../interfaces/entityidentifier.md) ; resolve: string ; variables?: Record\<string, any>  }): Promise\<any>
 
-*Defined in [AssistantAPIClient.ts:332](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L332)*
+*Defined in [AssistantAPIClient.ts:332](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L332)*
 
 Runs a query against a given function with the supplied variables and
 resolve string.
@@ -354,7 +354,7 @@ ___
 
 ▸ **executeGraphql**(`input`: { query: string ; serviceId: string ; variables?: Record\<string, any>  }): Promise\<any>
 
-*Defined in [AssistantAPIClient.ts:264](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L264)*
+*Defined in [AssistantAPIClient.ts:264](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L264)*
 
 Runs an arbitrary GraphQL query against a service in the platform.
 
@@ -374,7 +374,7 @@ ___
 
 ▸ **getAllReferencedKinds**(`data`: { entities: [EntityIdentifier](../interfaces/entityidentifier.md)[] ; entitiesToSkip: [EntityIdentifier](../interfaces/entityidentifier.md) ; maxDepth?: number  }): Promise\<[Kind](../interfaces/kind.md)[]>
 
-*Defined in [AssistantAPIClient.ts:592](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L592)*
+*Defined in [AssistantAPIClient.ts:592](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L592)*
 
 Loads up tree of Kinds references by the signature of the Entities passed in.
 
@@ -394,7 +394,7 @@ ___
 
 ▸ **getCurrentSelection**(): Promise\<[Selected](../interfaces/selected.md)>
 
-*Defined in [AssistantAPIClient.ts:190](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L190)*
+*Defined in [AssistantAPIClient.ts:190](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L190)*
 
 Gets the current selection from the UI.
 
@@ -408,7 +408,7 @@ ___
 
 ▸ **getFunctionById**(`id`: string): Promise\<[Maybe](../README.md#maybe)\<[Function](../interfaces/function.md)>>
 
-*Defined in [AssistantAPIClient.ts:396](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L396)*
+*Defined in [AssistantAPIClient.ts:396](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L396)*
 
 Loads a function by ID.  This can only return information about functions
 that the UI already has loaded into memory.
@@ -432,7 +432,7 @@ ___
 
 ▸ **getFunctionGraph**(`id`: string): Promise\<[Maybe](../README.md#maybe)\<[Function](../interfaces/function.md)>>
 
-*Defined in [AssistantAPIClient.ts:671](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L671)*
+*Defined in [AssistantAPIClient.ts:671](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L671)*
 
 Loads the function with its graph information attached.
 
@@ -456,7 +456,7 @@ ___
 
 ▸ **getFunctionOfServiceByName**(`serviceId`: string, `name`: string): Promise\<[Maybe](../README.md#maybe)\<[Function](../interfaces/function.md)>>
 
-*Defined in [AssistantAPIClient.ts:423](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L423)*
+*Defined in [AssistantAPIClient.ts:423](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L423)*
 
 Returns a function with the given name from a specific service.
 
@@ -477,7 +477,7 @@ ___
 
 ▸ **getFunctionsById**(`ids`: string[]): Promise\<[Function](../interfaces/function.md)[]>
 
-*Defined in [AssistantAPIClient.ts:411](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L411)*
+*Defined in [AssistantAPIClient.ts:411](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L411)*
 
 Loads a list of functions by ID.  This can only return information about
 functions that the UI already has loaded into memory.
@@ -501,7 +501,7 @@ ___
 
 ▸ **getFunctionsOfServiceByName**(`serviceId`: string, `names`: string[]): Promise\<[Function](../interfaces/function.md)[]>
 
-*Defined in [AssistantAPIClient.ts:438](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L438)*
+*Defined in [AssistantAPIClient.ts:438](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L438)*
 
 Returns a list of functions with the given names from a specific service.
 
@@ -522,7 +522,7 @@ ___
 
 ▸ **getKindById**(`id`: string): Promise\<[Maybe](../README.md#maybe)\<[Kind](../interfaces/kind.md)>>
 
-*Defined in [AssistantAPIClient.ts:533](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L533)*
+*Defined in [AssistantAPIClient.ts:533](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L533)*
 
 Loads a Kind by ID.  This can only return information about Kinds that the
 UI already has loaded into memory.
@@ -546,7 +546,7 @@ ___
 
 ▸ **getKindOfServiceByName**(`serviceId`: string, `name`: string): Promise\<[Maybe](../README.md#maybe)\<[Kind](../interfaces/kind.md)>>
 
-*Defined in [AssistantAPIClient.ts:560](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L560)*
+*Defined in [AssistantAPIClient.ts:560](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L560)*
 
 Returns a Kind with the given name from a specific service.
 
@@ -567,7 +567,7 @@ ___
 
 ▸ **getKindsById**(`ids`: string[]): Promise\<[Kind](../interfaces/kind.md)[]>
 
-*Defined in [AssistantAPIClient.ts:548](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L548)*
+*Defined in [AssistantAPIClient.ts:548](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L548)*
 
 Loads a list of Kinds by ID.  This can only return information about Kinds
 that the UI already has loaded into memory.
@@ -591,7 +591,7 @@ ___
 
 ▸ **getKindsOfServiceByName**(`serviceId`: string, `names`: string[]): Promise\<[Kind](../interfaces/kind.md)[]>
 
-*Defined in [AssistantAPIClient.ts:575](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L575)*
+*Defined in [AssistantAPIClient.ts:575](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L575)*
 
 Returns a list of Kinds with the given names from a specific service.
 
@@ -612,7 +612,7 @@ ___
 
 ▸ **getRenderMode**(): Promise\<string>
 
-*Defined in [AssistantAPIClient.ts:712](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L712)*
+*Defined in [AssistantAPIClient.ts:712](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L712)*
 
 Gets the current render mode for the assistant.
 
@@ -626,7 +626,7 @@ ___
 
 ▸ **getServiceById**(`id`: string): Promise\<[Maybe](../README.md#maybe)\<[Service](../interfaces/service.md)>>
 
-*Defined in [AssistantAPIClient.ts:205](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L205)*
+*Defined in [AssistantAPIClient.ts:205](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L205)*
 
 Gets a specified service by ID
 
@@ -646,7 +646,7 @@ ___
 
 ▸ **getUserAccessibleWorkspaces**(`includePublic?`: boolean): Promise\<[Workspace](../interfaces/workspace.md)[]>
 
-*Defined in [AssistantAPIClient.ts:297](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L297)*
+*Defined in [AssistantAPIClient.ts:297](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L297)*
 
 Returns a list of user accessible Workspaces.  By default it will just be
 the user owned Workspaces, but can be configured to also return all the
@@ -668,7 +668,7 @@ ___
 
 ▸ **getUserInfo**(): Promise\<[User](../interfaces/user.md)>
 
-*Defined in [AssistantAPIClient.ts:153](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L153)*
+*Defined in [AssistantAPIClient.ts:153](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L153)*
 
 Gets the information about the current user.
 
@@ -682,7 +682,7 @@ ___
 
 ▸ **getWorkspace**(`id?`: string): Promise\<[Maybe](../README.md#maybe)\<[Workspace](../interfaces/workspace.md)>>
 
-*Defined in [AssistantAPIClient.ts:284](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L284)*
+*Defined in [AssistantAPIClient.ts:284](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L284)*
 
 Returns the requested Workspace, if no Workspace ID is specified it returns
 the Workspace that the user is currently using.
@@ -703,13 +703,13 @@ ___
 
 ▸ **moveKindsAndFunctions**(`originId`: string, `targetId`: string, `kindIds`: string[], `functionIds`: string[]): Promise\<void>
 
-*Defined in [AssistantAPIClient.ts:642](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L642)*
+*Defined in [AssistantAPIClient.ts:642](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L642)*
 
 Moves a collection of Kinds and Functions from the origin Workspace to the
 target Workspace.
 
-**`deprecated`** This has been deprecated in favor of calling it directly off of
-the origin workspace.
+**`deprecated`** This has been deprecated in favor of calling update on the
+target Workspace to move the entities.
 
 #### Parameters:
 
@@ -728,7 +728,7 @@ ___
 
 ▸ **refreshServiceSchema**(`input`: string): Promise\<[Maybe](../README.md#maybe)\<[Service](../interfaces/service.md)>>
 
-*Defined in [AssistantAPIClient.ts:229](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L229)*
+*Defined in [AssistantAPIClient.ts:229](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L229)*
 
 Refreshed the service information in the backend.  This is useful for
 making sure that the platform is working on the latest schema of an
@@ -750,7 +750,7 @@ ___
 
 ▸ **reloadServiceSchema**(`id`: string): Promise\<[Maybe](../README.md#maybe)\<[Service](../interfaces/service.md)>>
 
-*Defined in [AssistantAPIClient.ts:241](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L241)*
+*Defined in [AssistantAPIClient.ts:241](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L241)*
 
 Has the UI reload the information about the service from the backend to
 make sure that it has fresh information.
@@ -771,7 +771,7 @@ ___
 
 ▸ **removeFunctionExecutionListener**(`id`: string, `cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:465](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L465)*
+*Defined in [AssistantAPIClient.ts:465](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L465)*
 
 Removes one or all callbacks listening for the function to be executed.
 
@@ -790,7 +790,7 @@ ___
 
 ▸ **removeInventoryChangedListener**(`cb?`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:619](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L619)*
+*Defined in [AssistantAPIClient.ts:619](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L619)*
 
 Removed a listener from the inventory changed event, or all of them if one
 is not specified.
@@ -809,7 +809,7 @@ ___
 
 ▸ **removeLockingChangedListener**(`cb?`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:780](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L780)*
+*Defined in [AssistantAPIClient.ts:780](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L780)*
 
 Removes a callback function from the list be called every time the locking
 changed event is triggered.  If no callback is passed in, then all
@@ -829,7 +829,7 @@ ___
 
 ▸ **removeRenderModeChangedListener**(`cb`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:696](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L696)*
+*Defined in [AssistantAPIClient.ts:696](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L696)*
 
 Removed a listener from the render mode changed event, or all of them if
 one is not specified.
@@ -848,7 +848,7 @@ ___
 
 ▸ **removeRepairListener**(`cb?`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:737](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L737)*
+*Defined in [AssistantAPIClient.ts:737](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L737)*
 
 Removed a listener from the repair changed event, or all of them if one is
 not specified.
@@ -869,7 +869,7 @@ ___
 
 ▸ **removeSelectionChangedListener**(`cb?`: [EventListenerCallback](../README.md#eventlistenercallback)): void
 
-*Defined in [AssistantAPIClient.ts:176](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L176)*
+*Defined in [AssistantAPIClient.ts:176](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L176)*
 
 Removed a listener from the selection changed event, or all of them if no
 callback is defined.
@@ -888,7 +888,7 @@ ___
 
 ▸ **reportError**(`error`: Error \| string): Promise\<void>
 
-*Defined in [AssistantAPIClient.ts:755](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L755)*
+*Defined in [AssistantAPIClient.ts:755](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L755)*
 
 Reports an error to the UI for the user to be able view it.
 
@@ -906,7 +906,7 @@ ___
 
 ▸ **setAssistantState**(`state`: [AssistantState](../enums/assistantstate.md)): Promise\<void>
 
-*Defined in [AssistantAPIClient.ts:129](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L129)*
+*Defined in [AssistantAPIClient.ts:129](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L129)*
 
 Updates the current state of the Assistant.
 
@@ -924,7 +924,7 @@ ___
 
 ▸ **updateFunction**(`input`: [UpdateFunctionInput](../interfaces/updatefunctioninput.md)): Promise\<[Function](../interfaces/function.md)>
 
-*Defined in [AssistantAPIClient.ts:367](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L367)*
+*Defined in [AssistantAPIClient.ts:367](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L367)*
 
 Updates a Function in the active workspace with the given information.
 
@@ -947,7 +947,7 @@ ___
 
 ▸ **updateKind**(`input`: [UpdateTypeInput](../interfaces/updatetypeinput.md)): Promise\<[Kind](../interfaces/kind.md)>
 
-*Defined in [AssistantAPIClient.ts:506](https://github.com/maana-io/q-assistant-client/blob/18eccdb/src/AssistantAPIClient.ts#L506)*
+*Defined in [AssistantAPIClient.ts:506](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L506)*
 
 Updates a Kind in the active workspace with the given information.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.3.0-beta.8",
+  "version": "3.3.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.3.0-beta.8",
+  "version": "3.3.0-beta.9",
   "description": "JavaScript package to streamline communication between an assistant and the Maana Q Assistant API.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/AssistantAPIClient.ts
+++ b/src/AssistantAPIClient.ts
@@ -71,7 +71,7 @@ function createAPIListener(callName: string, cb: EventListenerCallback) {
  * Attach selection event emitter to API listener
  * @private
  */
-createAPIListener(EventTypes.SELECTION_CHANGED, async function (event) {
+createAPIListener(EventTypes.SELECTION_CHANGED, async function(event) {
   eventEmitter.emit(EventTypes.SELECTION_CHANGED, event.data);
 });
 
@@ -80,7 +80,7 @@ createAPIListener(EventTypes.SELECTION_CHANGED, async function (event) {
  * Use convention to filter by function ID.
  * @private
  */
-createAPIListener(EventTypes.FUNCTION_EXECUTED, async function (event) {
+createAPIListener(EventTypes.FUNCTION_EXECUTED, async function(event) {
   eventEmitter.emit(`function:${event.data.id}`, event.data.result);
 });
 
@@ -88,7 +88,7 @@ createAPIListener(EventTypes.FUNCTION_EXECUTED, async function (event) {
  * Attach inventory event emitter to API listener.
  * @private
  */
-createAPIListener(EventTypes.INVENTORY_CHANGED, async function (event) {
+createAPIListener(EventTypes.INVENTORY_CHANGED, async function(event) {
   eventEmitter.emit(EventTypes.INVENTORY_CHANGED, event.data);
 });
 
@@ -96,7 +96,7 @@ createAPIListener(EventTypes.INVENTORY_CHANGED, async function (event) {
  * Attach render mode event emitter to API listener.
  * @private
  */
-createAPIListener(EventTypes.RENDER_MODE_CHANGED, async function (event) {
+createAPIListener(EventTypes.RENDER_MODE_CHANGED, async function(event) {
   eventEmitter.emit(EventTypes.RENDER_MODE_CHANGED, event.data);
 });
 
@@ -104,7 +104,7 @@ createAPIListener(EventTypes.RENDER_MODE_CHANGED, async function (event) {
  * Attach repair listener.
  * @private
  */
-createAPIListener(EventTypes.REPAIR, async function (event) {
+createAPIListener(EventTypes.REPAIR, async function(event) {
   eventEmitter.emit(EventTypes.REPAIR, event.data);
 });
 
@@ -112,7 +112,7 @@ createAPIListener(EventTypes.REPAIR, async function (event) {
  * Attach locking changed listener.
  * @private
  */
-createAPIListener(EventTypes.LOCKING_CHANGED, async function (event) {
+createAPIListener(EventTypes.LOCKING_CHANGED, async function(event) {
   eventEmitter.emit(EventTypes.LOCKING_CHANGED, event.data);
 });
 
@@ -631,8 +631,8 @@ export namespace AssistantAPIClient {
    * Moves a collection of Kinds and Functions from the origin Workspace to the
    * target Workspace.
    *
-   * @deprecated This has been deprecated in favor of calling it directly off of
-   * the origin workspace.
+   * @deprecated This has been deprecated in favor of calling update on the
+   * target Workspace to move the entities.
    *
    * @param originId The ID of the origin Workspace.
    * @param targetId The ID of the target Workspace.

--- a/src/models.ts
+++ b/src/models.ts
@@ -836,6 +836,13 @@ export interface UpdateWorkspaceInput {
   createEntities?: Maybe<Array<CreateEntityInput>>;
   cloneEntities?: Maybe<Array<CloneEntityInput>>;
   updateEntities?: Maybe<Array<UpdateEntityInput>>;
+
+  /**
+   * Moves the given entities from their current Workspace to this one.
+   * Currently only Types and Functions support being moved between Workspaces.
+   */
+  moveEntities?: Maybe<Array<EntityIdentifier>>;
+
   deleteEntities?: Maybe<Array<EntityIdentifier>>;
   addServices?: Maybe<Array<string>>;
   removeServices?: Maybe<Array<string>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "plugin": "typedoc-plugin-markdown",
     "excludePrivate": true,
     "excludeNotExported": true,
-    "readme": "none"
+    "readme": "none",
+    "gitRevision": "develop"
   }
 }


### PR DESCRIPTION
https://maanainc.atlassian.net/browse/QP-2263

* Deprecate the old top level move function.
* Add move functionality to the update workspace function.
* Update the documentation so that every change does not cause every file to be updated.

Update workspace to move entities:
![Screen Shot 2021-03-10 at 10 48 20 AM](https://user-images.githubusercontent.com/950818/110680990-26217c80-818e-11eb-90fc-48b15d012092.png)
