### PR TITLE
QP-2709: Add getWorkspace to the service object

### DIFF
--- a/docs/interfaces/argumentfieldselectioninput.md
+++ b/docs/interfaces/argumentfieldselectioninput.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:720](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L720)*
+*Defined in [models.ts:727](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L727)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • `Optional` **fieldSelection**: [Maybe](../README.md#maybe)\<Array\<Array\<string>>>
 
-*Defined in [models.ts:721](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L721)*
+*Defined in [models.ts:728](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L728)*

--- a/docs/interfaces/assistant.md
+++ b/docs/interfaces/assistant.md
@@ -55,7 +55,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:406](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L406)*
+*Defined in [models.ts:413](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L413)*
 
 The location that the Assistant can be reached at.
 
@@ -89,7 +89,7 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:412](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L412)*
+*Defined in [models.ts:419](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L419)*
 
 The current version of the Assistant.  This is incremented by catalog each
 time the Assistant is updated.
@@ -100,7 +100,7 @@ time the Assistant is updated.
 
 ▸ **update**(`changes`: [UpdateAssistantInput](updateassistantinput.md)): Promise\<void>
 
-*Defined in [models.ts:418](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L418)*
+*Defined in [models.ts:425](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L425)*
 
 Updates information about the Assistant.
 

--- a/docs/interfaces/cloneentityinput.md
+++ b/docs/interfaces/cloneentityinput.md
@@ -23,7 +23,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:759](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L759)*
+*Defined in [models.ts:766](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L766)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **newName**: string
 
-*Defined in [models.ts:762](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L762)*
+*Defined in [models.ts:769](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L769)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **oldName**: string
 
-*Defined in [models.ts:760](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L760)*
+*Defined in [models.ts:767](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L767)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **oldServiceId**: string
 
-*Defined in [models.ts:761](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L761)*
+*Defined in [models.ts:768](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L768)*

--- a/docs/interfaces/createconnectioninput.md
+++ b/docs/interfaces/createconnectioninput.md
@@ -21,7 +21,7 @@
 
 •  **from**: [GraphRefInput](graphrefinput.md)
 
-*Defined in [models.ts:693](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L693)*
+*Defined in [models.ts:700](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L700)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **to**: [GraphRefInput](graphrefinput.md)
 
-*Defined in [models.ts:694](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L694)*
+*Defined in [models.ts:701](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L701)*

--- a/docs/interfaces/createentityinput.md
+++ b/docs/interfaces/createentityinput.md
@@ -24,7 +24,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:751](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L751)*
+*Defined in [models.ts:758](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L758)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **file**: [Maybe](../README.md#maybe)\<[CreateFileInput](createfileinput.md)>
 
-*Defined in [models.ts:755](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L755)*
+*Defined in [models.ts:762](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L762)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **function**: [Maybe](../README.md#maybe)\<[CreateFunctionInput](createfunctioninput.md)>
 
-*Defined in [models.ts:754](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L754)*
+*Defined in [models.ts:761](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L761)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **knowledgeGraph**: [Maybe](../README.md#maybe)\<[CreateKnowledgeGraphInput](createknowledgegraphinput.md)>
 
-*Defined in [models.ts:752](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L752)*
+*Defined in [models.ts:759](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L759)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **type**: [Maybe](../README.md#maybe)\<[CreateTypeInput](createtypeinput.md)>
 
-*Defined in [models.ts:753](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L753)*
+*Defined in [models.ts:760](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L760)*

--- a/docs/interfaces/createfileinput.md
+++ b/docs/interfaces/createfileinput.md
@@ -30,7 +30,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:739](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L739)*
+*Defined in [models.ts:746](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L746)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:737](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L737)*
+*Defined in [models.ts:744](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L744)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • `Optional` **loadExternalMetadata**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:747](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L747)*
+*Defined in [models.ts:754](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L754)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • `Optional` **mimeType**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:743](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L743)*
+*Defined in [models.ts:750](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L750)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:738](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L738)*
+*Defined in [models.ts:745](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L745)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • `Optional` **progress**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:745](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L745)*
+*Defined in [models.ts:752](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L752)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 •  **serviceId**: string
 
-*Defined in [models.ts:740](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L740)*
+*Defined in [models.ts:747](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L747)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • `Optional` **size**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:744](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L744)*
+*Defined in [models.ts:751](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L751)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • `Optional` **status**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:746](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L746)*
+*Defined in [models.ts:753](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L753)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:742](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L742)*
+*Defined in [models.ts:749](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L749)*
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 •  **url**: string
 
-*Defined in [models.ts:741](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L741)*
+*Defined in [models.ts:748](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L748)*

--- a/docs/interfaces/createfunctioninput.md
+++ b/docs/interfaces/createfunctioninput.md
@@ -28,7 +28,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:727](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L727)*
+*Defined in [models.ts:734](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L734)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • `Optional` **graphImplementation**: [Maybe](../README.md#maybe)\<[CreateGraphInput](creategraphinput.md)>
 
-*Defined in [models.ts:732](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L732)*
+*Defined in [models.ts:739](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L739)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 •  **graphqlFunctionType**: [GraphQLFunctionType](../enums/graphqlfunctiontype.md)
 
-*Defined in [models.ts:730](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L730)*
+*Defined in [models.ts:737](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L737)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:725](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L725)*
+*Defined in [models.ts:732](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L732)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 •  **implementation**: [ImplementationType](../enums/implementationtype.md)
 
-*Defined in [models.ts:731](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L731)*
+*Defined in [models.ts:738](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L738)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • `Optional` **inputMask**: [Maybe](../README.md#maybe)\<Array\<[ArgumentFieldSelectionInput](argumentfieldselectioninput.md)>>
 
-*Defined in [models.ts:733](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L733)*
+*Defined in [models.ts:740](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L740)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • `Optional` **isPure**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:729](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L729)*
+*Defined in [models.ts:736](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L736)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:726](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L726)*
+*Defined in [models.ts:733](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L733)*
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:728](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L728)*
+*Defined in [models.ts:735](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L735)*

--- a/docs/interfaces/creategraphinput.md
+++ b/docs/interfaces/creategraphinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **connections**: [Maybe](../README.md#maybe)\<Array\<[CreateConnectionInput](createconnectioninput.md)>>
 
-*Defined in [models.ts:701](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L701)*
+*Defined in [models.ts:708](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L708)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **nodes**: [Maybe](../README.md#maybe)\<Array\<[CreateNodeInput](createnodeinput.md)>>
 
-*Defined in [models.ts:700](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L700)*
+*Defined in [models.ts:707](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L707)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **offset**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:698](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L698)*
+*Defined in [models.ts:705](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L705)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **zoom**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:699](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L699)*
+*Defined in [models.ts:706](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L706)*

--- a/docs/interfaces/createknowledgegraphinput.md
+++ b/docs/interfaces/createknowledgegraphinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:707](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L707)*
+*Defined in [models.ts:714](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L714)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **graph**: [Maybe](../README.md#maybe)\<[CreateGraphInput](creategraphinput.md)>
 
-*Defined in [models.ts:708](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L708)*
+*Defined in [models.ts:715](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L715)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:705](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L705)*
+*Defined in [models.ts:712](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L712)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:706](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L706)*
+*Defined in [models.ts:713](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L713)*

--- a/docs/interfaces/createnodeinput.md
+++ b/docs/interfaces/createnodeinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:667](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L667)*
+*Defined in [models.ts:674](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L674)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Optional` **entity**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:669](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L669)*
+*Defined in [models.ts:676](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L676)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:664](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L664)*
+*Defined in [models.ts:671](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L671)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isCollapsed**: [Maybe](../README.md#maybe)\<string[]>
 
-*Defined in [models.ts:666](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L666)*
+*Defined in [models.ts:673](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L673)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:665](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L665)*
+*Defined in [models.ts:672](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L672)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **operation**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:670](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L670)*
+*Defined in [models.ts:677](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L677)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:668](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L668)*
+*Defined in [models.ts:675](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L675)*

--- a/docs/interfaces/createserviceinput.md
+++ b/docs/interfaces/createserviceinput.md
@@ -28,7 +28,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:646](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L646)*
+*Defined in [models.ts:653](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L653)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 •  **endpointUrl**: string
 
-*Defined in [models.ts:647](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L647)*
+*Defined in [models.ts:654](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L654)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:643](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L643)*
+*Defined in [models.ts:650](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L650)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • `Optional` **isReadOnly**: boolean
 
-*Defined in [models.ts:650](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L650)*
+*Defined in [models.ts:657](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L657)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • `Optional` **isSystem**: boolean
 
-*Defined in [models.ts:649](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L649)*
+*Defined in [models.ts:656](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L656)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:645](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L645)*
+*Defined in [models.ts:652](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L652)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 •  **serviceType**: [ServiceType](../enums/servicetype.md)
 
-*Defined in [models.ts:644](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L644)*
+*Defined in [models.ts:651](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L651)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • `Optional` **tags**: Array\<string>
 
-*Defined in [models.ts:651](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L651)*
+*Defined in [models.ts:658](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L658)*
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:648](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L648)*
+*Defined in [models.ts:655](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L655)*

--- a/docs/interfaces/createtypeinput.md
+++ b/docs/interfaces/createtypeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:714](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L714)*
+*Defined in [models.ts:721](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L721)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:712](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L712)*
+*Defined in [models.ts:719](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L719)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isManaged**: boolean
 
-*Defined in [models.ts:716](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L716)*
+*Defined in [models.ts:723](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L723)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:713](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L713)*
+*Defined in [models.ts:720](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L720)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:715](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L715)*
+*Defined in [models.ts:722](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L722)*

--- a/docs/interfaces/createworkspaceinput.md
+++ b/docs/interfaces/createworkspaceinput.md
@@ -31,7 +31,7 @@
 
 • `Optional` **addServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:844](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L844)*
+*Defined in [models.ts:851](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L851)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **createEntities**: [Maybe](../README.md#maybe)\<Array\<[CreateEntityInput](createentityinput.md)>>
 
-*Defined in [models.ts:843](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L843)*
+*Defined in [models.ts:850](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L850)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:837](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L837)*
+*Defined in [models.ts:844](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L844)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:834](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L834)*
+*Defined in [models.ts:841](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L841)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 • `Optional` **isPublic**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:841](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L841)*
+*Defined in [models.ts:848](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L848)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 • `Optional` **isTemplate**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:842](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L842)*
+*Defined in [models.ts:849](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L849)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 • `Optional` **moveEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:850](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L850)*
+*Defined in [models.ts:857](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L857)*
 
 Moves the given entities from their current Workspace to this one.
 Currently only Types and Functions support being moved between Workspaces.
@@ -90,7 +90,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:836](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L836)*
+*Defined in [models.ts:843](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L843)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 •  **owner**: string
 
-*Defined in [models.ts:840](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L840)*
+*Defined in [models.ts:847](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L847)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • `Optional` **serviceId**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:835](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L835)*
+*Defined in [models.ts:842](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L842)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:839](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L839)*
+*Defined in [models.ts:846](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L846)*
 
 ___
 
@@ -122,4 +122,4 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:838](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L838)*
+*Defined in [models.ts:845](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L845)*

--- a/docs/interfaces/entitylockinput.md
+++ b/docs/interfaces/entitylockinput.md
@@ -20,4 +20,4 @@
 
 •  **lockedBy**: string
 
-*Defined in [models.ts:655](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L655)*
+*Defined in [models.ts:662](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L662)*

--- a/docs/interfaces/graphrefinput.md
+++ b/docs/interfaces/graphrefinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **argument**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:686](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L686)*
+*Defined in [models.ts:693](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L693)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **graphRefInputType**: [GraphRefInputType](../enums/graphrefinputtype.md)
 
-*Defined in [models.ts:685](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L685)*
+*Defined in [models.ts:692](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L692)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **operationArgument**: [Maybe](../README.md#maybe)\<[OperationArgumentRefInput](operationargumentrefinput.md)>
 
-*Defined in [models.ts:687](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L687)*
+*Defined in [models.ts:694](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L694)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **operationResult**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:688](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L688)*
+*Defined in [models.ts:695](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L695)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **outputArgument**: [Maybe](../README.md#maybe)\<[OutputArgumentRefInput](outputargumentrefinput.md)>
 
-*Defined in [models.ts:689](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L689)*
+*Defined in [models.ts:696](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L696)*

--- a/docs/interfaces/inventorychanged.md
+++ b/docs/interfaces/inventorychanged.md
@@ -22,7 +22,7 @@ The information returned from an inventory changed event.
 
 •  **diff**: { functions: { adds: [Maybe](../README.md#maybe)\<[Function](function.md)[]> ; deletes: [Maybe](../README.md#maybe)\<[Function](function.md)[]> ; updates: [Maybe](../README.md#maybe)\<[Function](function.md)[]>  } ; kinds: { adds: [Maybe](../README.md#maybe)\<[Kind](kind.md)[]> ; deletes: [Maybe](../README.md#maybe)\<[Kind](kind.md)[]> ; updates: [Maybe](../README.md#maybe)\<[Kind](kind.md)[]>  } ; services: { adds: [Maybe](../README.md#maybe)\<[Service](service.md)[]> ; deletes: [Maybe](../README.md#maybe)\<[Service](service.md)[]> ; updates: [Maybe](../README.md#maybe)\<[Service](service.md)[]>  }  }
 
-*Defined in [models.ts:879](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L879)*
+*Defined in [models.ts:886](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L886)*
 
 #### Type declaration:
 

--- a/docs/interfaces/lockchangeditem.md
+++ b/docs/interfaces/lockchangeditem.md
@@ -23,7 +23,7 @@ Information about an entity that had its locked state changed.
 
 •  **id**: string
 
-*Defined in [models.ts:900](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L900)*
+*Defined in [models.ts:907](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L907)*
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 •  **lock**: [Maybe](../README.md#maybe)\<{ email: string ; id: string  }>
 
-*Defined in [models.ts:901](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L901)*
+*Defined in [models.ts:908](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L908)*

--- a/docs/interfaces/lockingchanged.md
+++ b/docs/interfaces/lockingchanged.md
@@ -24,7 +24,7 @@ The information returned from an locking changed event.
 
 •  **functions**: [Maybe](../README.md#maybe)\<[LockChangedItem](lockchangeditem.md)[]>
 
-*Defined in [models.ts:911](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L911)*
+*Defined in [models.ts:918](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L918)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **knowledgeGraphs**: [Maybe](../README.md#maybe)\<[LockChangedItem](lockchangeditem.md)[]>
 
-*Defined in [models.ts:910](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L910)*
+*Defined in [models.ts:917](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L917)*
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 •  **workspaces**: [Maybe](../README.md#maybe)\<[LockChangedItem](lockchangeditem.md)[]>
 
-*Defined in [models.ts:909](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L909)*
+*Defined in [models.ts:916](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L916)*

--- a/docs/interfaces/operationargumentrefinput.md
+++ b/docs/interfaces/operationargumentrefinput.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:675](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L675)*
+*Defined in [models.ts:682](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L682)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:674](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L674)*
+*Defined in [models.ts:681](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L681)*

--- a/docs/interfaces/outputargumentrefinput.md
+++ b/docs/interfaces/outputargumentrefinput.md
@@ -22,7 +22,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:681](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L681)*
+*Defined in [models.ts:688](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L688)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **fieldPath**: Array\<string>
 
-*Defined in [models.ts:680](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L680)*
+*Defined in [models.ts:687](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L687)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:679](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L679)*
+*Defined in [models.ts:686](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L686)*

--- a/docs/interfaces/positioninput.md
+++ b/docs/interfaces/positioninput.md
@@ -21,7 +21,7 @@
 
 • `Optional` **x**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:659](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L659)*
+*Defined in [models.ts:666](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L666)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • `Optional` **y**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:660](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L660)*
+*Defined in [models.ts:667](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L667)*

--- a/docs/interfaces/service.md
+++ b/docs/interfaces/service.md
@@ -26,6 +26,7 @@
 
 * [getFunctions](service.md#getfunctions)
 * [getKinds](service.md#getkinds)
+* [getWorkspace](service.md#getworkspace)
 * [update](service.md#update)
 
 ## Properties
@@ -133,11 +134,25 @@ Retrieves the list of Kinds that are part of the Service.
 
 ___
 
+### getWorkspace
+
+▸ **getWorkspace**(): Promise\<[Maybe](../README.md#maybe)\<[Workspace](workspace.md)>>
+
+*Defined in [models.ts:402](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L402)*
+
+Loads the Workspace that is connected with the service. Only works for for
+Logic services. If there is no workspace connected with the service then
+null is returned.
+
+**Returns:** Promise\<[Maybe](../README.md#maybe)\<[Workspace](workspace.md)>>
+
+___
+
 ### update
 
 ▸ **update**(`changes`: [UpdateExternalGraphQLServiceInput](updateexternalgraphqlserviceinput.md)): Promise\<void>
 
-*Defined in [models.ts:401](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L401)*
+*Defined in [models.ts:408](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L408)*
 
 Updates information about the Service.
 

--- a/docs/interfaces/updateassistantinput.md
+++ b/docs/interfaces/updateassistantinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **endpointUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:635](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L635)*
+*Defined in [models.ts:642](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L642)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:633](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L633)*
+*Defined in [models.ts:640](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L640)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **isReadOnly**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:637](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L637)*
+*Defined in [models.ts:644](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L644)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isSystem**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:636](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L636)*
+*Defined in [models.ts:643](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L643)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:634](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L634)*
+*Defined in [models.ts:641](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L641)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:638](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L638)*
+*Defined in [models.ts:645](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L645)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:639](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L639)*
+*Defined in [models.ts:646](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L646)*

--- a/docs/interfaces/updateentityinput.md
+++ b/docs/interfaces/updateentityinput.md
@@ -24,7 +24,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:826](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L826)*
+*Defined in [models.ts:833](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L833)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **file**: [Maybe](../README.md#maybe)\<[UpdateFileInput](updatefileinput.md)>
 
-*Defined in [models.ts:830](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L830)*
+*Defined in [models.ts:837](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L837)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **function**: [Maybe](../README.md#maybe)\<[UpdateFunctionInput](updatefunctioninput.md)>
 
-*Defined in [models.ts:829](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L829)*
+*Defined in [models.ts:836](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L836)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **knowledgeGraph**: [Maybe](../README.md#maybe)\<[UpdateKnowledgeGraphInput](updateknowledgegraphinput.md)>
 
-*Defined in [models.ts:827](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L827)*
+*Defined in [models.ts:834](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L834)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **type**: [Maybe](../README.md#maybe)\<[UpdateTypeInput](updatetypeinput.md)>
 
-*Defined in [models.ts:828](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L828)*
+*Defined in [models.ts:835](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L835)*

--- a/docs/interfaces/updateexternalgraphqlserviceinput.md
+++ b/docs/interfaces/updateexternalgraphqlserviceinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **endpointUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:625](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L625)*
+*Defined in [models.ts:632](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L632)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:623](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L623)*
+*Defined in [models.ts:630](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L630)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **isReadOnly**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:627](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L627)*
+*Defined in [models.ts:634](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L634)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isSystem**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:626](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L626)*
+*Defined in [models.ts:633](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L633)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:624](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L624)*
+*Defined in [models.ts:631](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L631)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:628](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L628)*
+*Defined in [models.ts:635](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L635)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:629](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L629)*
+*Defined in [models.ts:636](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L636)*

--- a/docs/interfaces/updatefileinput.md
+++ b/docs/interfaces/updatefileinput.md
@@ -29,7 +29,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:815](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L815)*
+*Defined in [models.ts:822](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L822)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:813](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L813)*
+*Defined in [models.ts:820](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L820)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • `Optional` **mimeType**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:819](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L819)*
+*Defined in [models.ts:826](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L826)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:814](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L814)*
+*Defined in [models.ts:821](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L821)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • `Optional` **progress**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:821](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L821)*
+*Defined in [models.ts:828](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L828)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • `Optional` **serviceId**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:816](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L816)*
+*Defined in [models.ts:823](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L823)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • `Optional` **size**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:820](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L820)*
+*Defined in [models.ts:827](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L827)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • `Optional` **status**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:822](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L822)*
+*Defined in [models.ts:829](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L829)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:818](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L818)*
+*Defined in [models.ts:825](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L825)*
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • `Optional` **url**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:817](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L817)*
+*Defined in [models.ts:824](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L824)*

--- a/docs/interfaces/updatefunctioninput.md
+++ b/docs/interfaces/updatefunctioninput.md
@@ -29,7 +29,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:802](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L802)*
+*Defined in [models.ts:809](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L809)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • `Optional` **graphImplementation**: [Maybe](../README.md#maybe)\<[UpdateGraphInput](updategraphinput.md)>
 
-*Defined in [models.ts:808](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L808)*
+*Defined in [models.ts:815](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L815)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • `Optional` **graphqlFunctionType**: [Maybe](../README.md#maybe)\<[GraphQLFunctionType](../enums/graphqlfunctiontype.md)>
 
-*Defined in [models.ts:805](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L805)*
+*Defined in [models.ts:812](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L812)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:800](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L800)*
+*Defined in [models.ts:807](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L807)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • `Optional` **implementation**: [Maybe](../README.md#maybe)\<[ImplementationType](../enums/implementationtype.md)>
 
-*Defined in [models.ts:807](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L807)*
+*Defined in [models.ts:814](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L814)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • `Optional` **inputMask**: [Maybe](../README.md#maybe)\<Array\<[ArgumentFieldSelectionInput](argumentfieldselectioninput.md)>>
 
-*Defined in [models.ts:809](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L809)*
+*Defined in [models.ts:816](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L816)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • `Optional` **isPure**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:804](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L804)*
+*Defined in [models.ts:811](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L811)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:806](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L806)*
+*Defined in [models.ts:813](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L813)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:801](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L801)*
+*Defined in [models.ts:808](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L808)*
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • `Optional` **signature**: [Maybe](../README.md#maybe)\<[TypeExpressionObject](../README.md#typeexpressionobject)>
 
-*Defined in [models.ts:803](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L803)*
+*Defined in [models.ts:810](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L810)*

--- a/docs/interfaces/updategraphinput.md
+++ b/docs/interfaces/updategraphinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **createConnections**: [Maybe](../README.md#maybe)\<Array\<[CreateConnectionInput](createconnectioninput.md)>>
 
-*Defined in [models.ts:779](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L779)*
+*Defined in [models.ts:786](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L786)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Optional` **createNodes**: [Maybe](../README.md#maybe)\<Array\<[CreateNodeInput](createnodeinput.md)>>
 
-*Defined in [models.ts:776](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L776)*
+*Defined in [models.ts:783](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L783)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **deleteConnections**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:780](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L780)*
+*Defined in [models.ts:787](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L787)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **deleteNodes**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:778](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L778)*
+*Defined in [models.ts:785](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L785)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **offset**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:774](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L774)*
+*Defined in [models.ts:781](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L781)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **updateNodes**: [Maybe](../README.md#maybe)\<Array\<[UpdateNodeInput](updatenodeinput.md)>>
 
-*Defined in [models.ts:777](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L777)*
+*Defined in [models.ts:784](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L784)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 • `Optional` **zoom**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:775](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L775)*
+*Defined in [models.ts:782](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L782)*

--- a/docs/interfaces/updategraphlayoutinput.md
+++ b/docs/interfaces/updategraphlayoutinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **nodes**: [UpdateNodeLayoutInput](updatenodelayoutinput.md) & { id: string  }[]
 
-*Defined in [models.ts:619](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L619)*
+*Defined in [models.ts:626](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L626)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **offsetX**: number
 
-*Defined in [models.ts:617](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L617)*
+*Defined in [models.ts:624](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L624)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **offsetY**: number
 
-*Defined in [models.ts:618](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L618)*
+*Defined in [models.ts:625](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L625)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **zoom**: number
 
-*Defined in [models.ts:616](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L616)*
+*Defined in [models.ts:623](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L623)*

--- a/docs/interfaces/updateknowledgegraphinput.md
+++ b/docs/interfaces/updateknowledgegraphinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:786](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L786)*
+*Defined in [models.ts:793](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L793)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **graph**: [Maybe](../README.md#maybe)\<[UpdateGraphInput](updategraphinput.md)>
 
-*Defined in [models.ts:788](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L788)*
+*Defined in [models.ts:795](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L795)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:784](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L784)*
+*Defined in [models.ts:791](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L791)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:787](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L787)*
+*Defined in [models.ts:794](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L794)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:785](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L785)*
+*Defined in [models.ts:792](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L792)*

--- a/docs/interfaces/updatenodeinput.md
+++ b/docs/interfaces/updatenodeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:769](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L769)*
+*Defined in [models.ts:776](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L776)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:766](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L766)*
+*Defined in [models.ts:773](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L773)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isCollapsed**: [Maybe](../README.md#maybe)\<string[]>
 
-*Defined in [models.ts:768](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L768)*
+*Defined in [models.ts:775](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L775)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:767](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L767)*
+*Defined in [models.ts:774](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L774)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:770](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L770)*
+*Defined in [models.ts:777](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L777)*

--- a/docs/interfaces/updatenodelayoutinput.md
+++ b/docs/interfaces/updatenodelayoutinput.md
@@ -22,7 +22,7 @@
 
 • `Optional` **isCollapsed**: string[]
 
-*Defined in [models.ts:612](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L612)*
+*Defined in [models.ts:619](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L619)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • `Optional` **x**: number
 
-*Defined in [models.ts:610](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L610)*
+*Defined in [models.ts:617](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L617)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • `Optional` **y**: number
 
-*Defined in [models.ts:611](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L611)*
+*Defined in [models.ts:618](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L618)*

--- a/docs/interfaces/updatetypeinput.md
+++ b/docs/interfaces/updatetypeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:794](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L794)*
+*Defined in [models.ts:801](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L801)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:792](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L792)*
+*Defined in [models.ts:799](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L799)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isManaged**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:796](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L796)*
+*Defined in [models.ts:803](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L803)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:793](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L793)*
+*Defined in [models.ts:800](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L800)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **signature**: [Maybe](../README.md#maybe)\<[TypeExpressionObject](../README.md#typeexpressionobject)>
 
-*Defined in [models.ts:795](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L795)*
+*Defined in [models.ts:802](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L802)*

--- a/docs/interfaces/updateworkspaceinput.md
+++ b/docs/interfaces/updateworkspaceinput.md
@@ -34,7 +34,7 @@
 
 • `Optional` **addServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:873](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L873)*
+*Defined in [models.ts:880](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L880)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **cloneEntities**: [Maybe](../README.md#maybe)\<Array\<[CloneEntityInput](cloneentityinput.md)>>
 
-*Defined in [models.ts:863](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L863)*
+*Defined in [models.ts:870](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L870)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **createEntities**: [Maybe](../README.md#maybe)\<Array\<[CreateEntityInput](createentityinput.md)>>
 
-*Defined in [models.ts:862](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L862)*
+*Defined in [models.ts:869](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L869)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **deleteEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:872](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L872)*
+*Defined in [models.ts:879](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L879)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:856](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L856)*
+*Defined in [models.ts:863](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L863)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:854](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L854)*
+*Defined in [models.ts:861](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L861)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • `Optional` **isPublic**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:859](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L859)*
+*Defined in [models.ts:866](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L866)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 • `Optional` **isTemplate**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:860](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L860)*
+*Defined in [models.ts:867](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L867)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:861](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L861)*
+*Defined in [models.ts:868](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L868)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • `Optional` **moveEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:870](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L870)*
+*Defined in [models.ts:877](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L877)*
 
 Moves the given entities from their current Workspace to this one.
 Currently only Types and Functions support being moved between Workspaces.
@@ -117,7 +117,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:855](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L855)*
+*Defined in [models.ts:862](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L862)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 • `Optional` **removeServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:874](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L874)*
+*Defined in [models.ts:881](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L881)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:858](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L858)*
+*Defined in [models.ts:865](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L865)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:857](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L857)*
+*Defined in [models.ts:864](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L864)*
 
 ___
 
@@ -149,4 +149,4 @@ ___
 
 • `Optional` **updateEntities**: [Maybe](../README.md#maybe)\<Array\<[UpdateEntityInput](updateentityinput.md)>>
 
-*Defined in [models.ts:864](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L864)*
+*Defined in [models.ts:871](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L871)*

--- a/docs/interfaces/workspace.md
+++ b/docs/interfaces/workspace.md
@@ -91,7 +91,7 @@ ___
 
 •  **isPublic**: boolean
 
-*Defined in [models.ts:435](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L435)*
+*Defined in [models.ts:442](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L442)*
 
 When true others can see this Workspace.
 
@@ -101,7 +101,7 @@ ___
 
 •  **isTemplate**: boolean
 
-*Defined in [models.ts:438](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L438)*
+*Defined in [models.ts:445](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L445)*
 
 When true it shows up as a template Workspace.
 
@@ -111,7 +111,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:423](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L423)*
+*Defined in [models.ts:430](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L430)*
 
 The location information about the Workspace.
 
@@ -145,7 +145,7 @@ ___
 
 •  **owner**: { id: string ; name: string  }
 
-*Defined in [models.ts:444](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L444)*
+*Defined in [models.ts:451](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L451)*
 
 The user that owns the Workspace.
 
@@ -162,7 +162,7 @@ ___
 
 •  **persistenceServiceId**: string
 
-*Defined in [models.ts:432](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L432)*
+*Defined in [models.ts:439](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L439)*
 
 The ID of the model service handling persistence for the Workspace
 
@@ -172,7 +172,7 @@ ___
 
 •  **serviceId**: string
 
-*Defined in [models.ts:429](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L429)*
+*Defined in [models.ts:436](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L436)*
 
 The ID of the logic service backing the Workspace.
 
@@ -182,7 +182,7 @@ ___
 
 •  **tags**: string[]
 
-*Defined in [models.ts:441](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L441)*
+*Defined in [models.ts:448](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L448)*
 
 The list of tags for the Workspace.
 
@@ -192,7 +192,7 @@ ___
 
 •  **thumbnailUrl**: string
 
-*Defined in [models.ts:426](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L426)*
+*Defined in [models.ts:433](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L433)*
 
 The URL to the URL of the thumbnail pic.
 
@@ -202,7 +202,7 @@ The URL to the URL of the thumbnail pic.
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:447](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L447)*
+*Defined in [models.ts:454](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L454)*
 
 Returns boolean stating if the Workspace is editable.
 
@@ -214,7 +214,7 @@ ___
 
 ▸ **createFunction**(`input`: [CreateFunctionInput](createfunctioninput.md)): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:534](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L534)*
+*Defined in [models.ts:541](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L541)*
 
 Creates a new Function in the Workspace.
 
@@ -232,7 +232,7 @@ ___
 
 ▸ **createFunctions**(`input`: [CreateFunctionInput](createfunctioninput.md)[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:540](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L540)*
+*Defined in [models.ts:547](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L547)*
 
 Creates a list of new Functions in the Workspace.
 
@@ -250,7 +250,7 @@ ___
 
 ▸ **createKind**(`input`: [CreateTypeInput](createtypeinput.md)): Promise\<[Kind](kind.md)>
 
-*Defined in [models.ts:582](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L582)*
+*Defined in [models.ts:589](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L589)*
 
 Creates a new Kind in the Workspace.
 
@@ -268,7 +268,7 @@ ___
 
 ▸ **createKinds**(`input`: [CreateTypeInput](createtypeinput.md)[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:588](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L588)*
+*Defined in [models.ts:595](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L595)*
 
 Creates a list of Kinds in the Workspace.
 
@@ -286,7 +286,7 @@ ___
 
 ▸ **createKnowledgeGraph**(`input`: [CreateKnowledgeGraphInput](createknowledgegraphinput.md)): Promise\<void>
 
-*Defined in [models.ts:481](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L481)*
+*Defined in [models.ts:488](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L488)*
 
 Creates a new Knowledge Graph in the Workspace.
 
@@ -304,7 +304,7 @@ ___
 
 ▸ **createKnowledgeGraphs**(`input`: [CreateKnowledgeGraphInput](createknowledgegraphinput.md)[]): Promise\<void>
 
-*Defined in [models.ts:487](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L487)*
+*Defined in [models.ts:494](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L494)*
 
 Creates a list of new Knowledge Graphs in the Workspace.
 
@@ -322,7 +322,7 @@ ___
 
 ▸ **deleteFunction**(`name`: string): Promise\<void>
 
-*Defined in [models.ts:558](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L558)*
+*Defined in [models.ts:565](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L565)*
 
 Deletes a function in the Workspace.
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **deleteKind**(`name`: string): Promise\<void>
 
-*Defined in [models.ts:606](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L606)*
+*Defined in [models.ts:613](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L613)*
 
 Deletes a Kind in the Workspace.
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **getActiveGraph**(): Promise\<[Maybe](../README.md#maybe)\<[KnowledgeGraph](knowledgegraph.md) \| [Function](function.md)>>
 
-*Defined in [models.ts:472](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L472)*
+*Defined in [models.ts:479](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L479)*
 
 Gets the currently active graph.
 
@@ -370,7 +370,7 @@ ___
 
 ▸ **getFunctionGraph**(`id`: string): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:567](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L567)*
+*Defined in [models.ts:574](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L574)*
 
 Gets the Function based on ID with its implementation and graph
 information.
@@ -392,7 +392,7 @@ ___
 
 ▸ **getFunctions**(): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:522](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L522)*
+*Defined in [models.ts:529](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L529)*
 
 Gets the list of Functions that live in the Workspace.
 
@@ -404,7 +404,7 @@ ___
 
 ▸ **getFunctionsByName**(`names`: string[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:528](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L528)*
+*Defined in [models.ts:535](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L535)*
 
 Gets a list of Functions that live in the Workspace based on their names.
 
@@ -422,7 +422,7 @@ ___
 
 ▸ **getImportedAssistants**(): Promise\<[Assistant](assistant.md)[]>
 
-*Defined in [models.ts:493](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L493)*
+*Defined in [models.ts:500](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L500)*
 
 Gets all of the Assistants imported into the Workspaces inventory.
 
@@ -434,7 +434,7 @@ ___
 
 ▸ **getImportedServices**(): Promise\<[Service](service.md)[]>
 
-*Defined in [models.ts:490](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L490)*
+*Defined in [models.ts:497](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L497)*
 
 Gets all of the Services imported into the Workspaces inventory.
 
@@ -446,7 +446,7 @@ ___
 
 ▸ **getKinds**(): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:570](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L570)*
+*Defined in [models.ts:577](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L577)*
 
 Gets the list of Kinds that live in the Workspace.
 
@@ -458,7 +458,7 @@ ___
 
 ▸ **getKindsByName**(`names`: string[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:576](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L576)*
+*Defined in [models.ts:583](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L583)*
 
 Gets a list of Kinds that live in the Workspace based on their names.
 
@@ -476,7 +476,7 @@ ___
 
 ▸ **getKnowledgeGraphs**(): Promise\<[KnowledgeGraph](knowledgegraph.md)[]>
 
-*Defined in [models.ts:475](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L475)*
+*Defined in [models.ts:482](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L482)*
 
 Gets all of the Knowledge Graphs in the Workspace.
 
@@ -488,7 +488,7 @@ ___
 
 ▸ **importService**(`serviceId`: string): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:500](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L500)*
+*Defined in [models.ts:507](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L507)*
 
 Imports a Service or Assistant into the Workspaces inventory.
 
@@ -508,7 +508,7 @@ ___
 
 ▸ **importServices**(`serviceIds`: string[]): Promise\<string[]>
 
-*Defined in [models.ts:507](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L507)*
+*Defined in [models.ts:514](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L514)*
 
 Imports a list of Services and/or Assistants into the Workspaces inventory.
 
@@ -528,7 +528,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:450](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L450)*
+*Defined in [models.ts:457](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L457)*
 
 Returns the e-mail of the user who locked the Workspace.
 
@@ -540,7 +540,7 @@ ___
 
 ▸ **reload**(): Promise\<[Workspace](workspace.md)>
 
-*Defined in [models.ts:466](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L466)*
+*Defined in [models.ts:473](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L473)*
 
 Returns a new copy of the workspace with reloaded information.
 
@@ -552,7 +552,7 @@ ___
 
 ▸ **removeService**(`serviceId`: string): Promise\<void>
 
-*Defined in [models.ts:513](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L513)*
+*Defined in [models.ts:520](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L520)*
 
 Removes a Service or Assistant from the Workspaces inventory.
 
@@ -570,7 +570,7 @@ ___
 
 ▸ **removeServices**(`serviceIds`: string): Promise\<void>
 
-*Defined in [models.ts:519](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L519)*
+*Defined in [models.ts:526](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L526)*
 
 Removes a list Services and/or Assistants from the Workspaces inventory.
 
@@ -588,7 +588,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:457](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L457)*
+*Defined in [models.ts:464](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L464)*
 
 Updates the locked state of the Workspace.
 
@@ -606,7 +606,7 @@ ___
 
 ▸ **triggerRepairEvent**(): Promise\<void>
 
-*Defined in [models.ts:469](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L469)*
+*Defined in [models.ts:476](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L476)*
 
 Sends a repair event to all assistants.
 
@@ -618,7 +618,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateWorkspaceInput](updateworkspaceinput.md)): Promise\<void>
 
-*Defined in [models.ts:463](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L463)*
+*Defined in [models.ts:470](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L470)*
 
 Updates information about the Workspace.
 
@@ -636,7 +636,7 @@ ___
 
 ▸ **updateFunction**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:546](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L546)*
+*Defined in [models.ts:553](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L553)*
 
 Updates a Function in the Workspace.
 
@@ -654,7 +654,7 @@ ___
 
 ▸ **updateFunctions**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:552](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L552)*
+*Defined in [models.ts:559](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L559)*
 
 Updates a list of Function in the Workspace.
 
@@ -672,7 +672,7 @@ ___
 
 ▸ **updateKind**(`changes`: [UpdateTypeInput](updatetypeinput.md)): Promise\<[Kind](kind.md)>
 
-*Defined in [models.ts:594](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L594)*
+*Defined in [models.ts:601](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L601)*
 
 Updates a Kind in the Workspace.
 
@@ -690,7 +690,7 @@ ___
 
 ▸ **updateKinds**(`changes`: [UpdateTypeInput](updatetypeinput.md)[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:600](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L600)*
+*Defined in [models.ts:607](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L607)*
 
 Updates a list of Kinds in the Workspace.
 

--- a/docs/modules/assistantapiclient.md
+++ b/docs/modules/assistantapiclient.md
@@ -1033,7 +1033,7 @@ ___
 
 ### removeRepairListener
 
-▸ **removeRepairListener**(`cb?`: (worksapceId: string) => void): void
+▸ **removeRepairListener**(`cb?`: (workspaceId: string) => void): void
 
 *Defined in [AssistantAPIClient.ts:948](https://github.com/maana-io/q-assistant-client/blob/develop/src/AssistantAPIClient.ts#L948)*
 
@@ -1049,7 +1049,7 @@ AssistantAPIClient.removeRepairListener(handleRepair)
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`cb?` | (worksapceId: string) => void | Callback function.  |
+`cb?` | (workspaceId: string) => void | Callback function.  |
 
 **Returns:** void
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.3.0-beta.16",
+  "version": "3.3.0-beta.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.3.0-beta.16",
+  "version": "3.3.0-beta.17",
   "description": "JavaScript package to streamline communication between an assistant and the Maana Q Assistant API.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/AssistantAPIClient.ts
+++ b/src/AssistantAPIClient.ts
@@ -946,7 +946,7 @@ export namespace AssistantAPIClient {
    * @param cb Callback function.
    */
   export function removeRepairListener(
-    cb?: (worksapceId: string) => void
+    cb?: (workspaceId: string) => void
   ): void {
     // If the callback is not provided, then remove all of the listeners.
     if (cb) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -395,6 +395,13 @@ export interface Service extends Entity {
   getFunctions(): Promise<Function[]>;
 
   /**
+   * Loads the Workspace that is connected with the service. Only works for for
+   * Logic services. If there is no workspace connected with the service then
+   * null is returned.
+   * */
+  getWorkspace(): Promise<Maybe<Workspace>>;
+
+  /**
    * Updates information about the Service.
    * @param changes Information to update the Service with.
    */


### PR DESCRIPTION
https://maanainc.atlassian.net/browse/QP-2709

Adds the `getWorkspace` endpoint to services so that a logic services backing workspace can be easily loaded.