### PR TITLE
QP-2712: Add annotations to the Assistant API (3.3.0)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 
 ### Interfaces
 
+* [Annotation](interfaces/annotation.md)
 * [ArgumentFieldSelection](interfaces/argumentfieldselection.md)
 * [ArgumentFieldSelectionInput](interfaces/argumentfieldselectioninput.md)
 * [ArgumentRef](interfaces/argumentref.md)
@@ -33,6 +34,7 @@
 * [AssistantAPIError](interfaces/assistantapierror.md)
 * [CloneEntityInput](interfaces/cloneentityinput.md)
 * [Connection](interfaces/connection.md)
+* [CreateAnnotationInput](interfaces/createannotationinput.md)
 * [CreateConnectionInput](interfaces/createconnectioninput.md)
 * [CreateEntityInput](interfaces/createentityinput.md)
 * [CreateFileInput](interfaces/createfileinput.md)
@@ -68,6 +70,7 @@
 * [Selected](interfaces/selected.md)
 * [Service](interfaces/service.md)
 * [ServiceLocation](interfaces/servicelocation.md)
+* [UpdateAnnotationInput](interfaces/updateannotationinput.md)
 * [UpdateAssistantInput](interfaces/updateassistantinput.md)
 * [UpdateEntityInput](interfaces/updateentityinput.md)
 * [UpdateExternalGraphQLServiceInput](interfaces/updateexternalgraphqlserviceinput.md)
@@ -109,7 +112,7 @@ ___
 
 Ƭ  **GraphRef**: [ArgumentRef](interfaces/argumentref.md) \| [OperationArgumentRef](interfaces/operationargumentref.md) \| [FunctionResultRef](interfaces/functionresultref.md) \| [OperationResultRef](interfaces/operationresultref.md) \| [OutputArgumentRef](interfaces/outputargumentref.md)
 
-*Defined in [models.ts:111](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L111)*
+*Defined in [models.ts:119](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L119)*
 
 Info for one end of a connection between two items within the graph.
 
@@ -119,7 +122,7 @@ ___
 
 Ƭ  **Implementation**: [Graph](interfaces/graph.md)
 
-*Defined in [models.ts:275](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L275)*
+*Defined in [models.ts:283](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L283)*
 
 Function implementation union.
 

--- a/docs/enums/entitytype.md
+++ b/docs/enums/entitytype.md
@@ -12,6 +12,7 @@ from selection or used in graph nodes.
 ### Enumeration members
 
 * [ACTIVITY](entitytype.md#activity)
+* [ANNOTATION](entitytype.md#annotation)
 * [CONNECTION](entitytype.md#connection)
 * [FILE](entitytype.md#file)
 * [FUNCTION](entitytype.md#function)
@@ -30,7 +31,15 @@ from selection or used in graph nodes.
 
 •  **ACTIVITY**:  = "ACTIVITY"
 
-*Defined in [constants.ts:55](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L55)*
+*Defined in [constants.ts:56](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L56)*
+
+___
+
+### ANNOTATION
+
+•  **ANNOTATION**:  = "ANNOTATION"
+
+*Defined in [constants.ts:42](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L42)*
 
 ___
 
@@ -38,7 +47,7 @@ ___
 
 •  **CONNECTION**:  = "CONNECTION"
 
-*Defined in [constants.ts:51](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L51)*
+*Defined in [constants.ts:52](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L52)*
 
 ___
 
@@ -46,7 +55,7 @@ ___
 
 •  **FILE**:  = "FILE"
 
-*Defined in [constants.ts:42](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L42)*
+*Defined in [constants.ts:43](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L43)*
 
 ___
 
@@ -54,7 +63,7 @@ ___
 
 •  **FUNCTION**:  = "FUNCTION"
 
-*Defined in [constants.ts:43](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L43)*
+*Defined in [constants.ts:44](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L44)*
 
 ___
 
@@ -62,7 +71,7 @@ ___
 
 •  **FUNCTION\_ARGUMENTS**:  = "FUNCTION\_ARGUMENTS"
 
-*Defined in [constants.ts:52](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L52)*
+*Defined in [constants.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L53)*
 
 ___
 
@@ -70,7 +79,7 @@ ___
 
 •  **FUNCTION\_OUTPUT**:  = "FUNCTION\_OUTPUT"
 
-*Defined in [constants.ts:53](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L53)*
+*Defined in [constants.ts:54](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L54)*
 
 ___
 
@@ -78,7 +87,7 @@ ___
 
 •  **GRAPH\_NODE**:  = "GRAPH\_NODE"
 
-*Defined in [constants.ts:54](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L54)*
+*Defined in [constants.ts:55](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L55)*
 
 ___
 
@@ -86,7 +95,7 @@ ___
 
 •  **KNOWLEDGE\_GRAPH**:  = "KNOWLEDGE\_GRAPH"
 
-*Defined in [constants.ts:44](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L44)*
+*Defined in [constants.ts:45](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L45)*
 
 ___
 
@@ -94,7 +103,7 @@ ___
 
 •  **SERVICE**:  = "SERVICE"
 
-*Defined in [constants.ts:45](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L45)*
+*Defined in [constants.ts:46](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L46)*
 
 ___
 
@@ -102,7 +111,7 @@ ___
 
 •  **TYPE**:  = "TYPE"
 
-*Defined in [constants.ts:46](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L46)*
+*Defined in [constants.ts:47](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L47)*
 
 ___
 
@@ -110,7 +119,7 @@ ___
 
 •  **VALUE**:  = "VALUE"
 
-*Defined in [constants.ts:47](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L47)*
+*Defined in [constants.ts:48](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L48)*
 
 ___
 
@@ -118,4 +127,4 @@ ___
 
 •  **WORKSPACE**:  = "WORKSPACE"
 
-*Defined in [constants.ts:48](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L48)*
+*Defined in [constants.ts:49](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L49)*

--- a/docs/enums/functiontype.md
+++ b/docs/enums/functiontype.md
@@ -19,7 +19,7 @@ The types of a functions.
 
 •  **CKG**:  = "CKG"
 
-*Defined in [constants.ts:73](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L73)*
+*Defined in [constants.ts:74](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L74)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 •  **EXTERNAL**:  = "EXTERNAL"
 
-*Defined in [constants.ts:72](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L72)*
+*Defined in [constants.ts:73](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L73)*

--- a/docs/enums/graphqlfunctiontype.md
+++ b/docs/enums/graphqlfunctiontype.md
@@ -21,7 +21,7 @@ The different GraphQL operations that the function can be used for.
 
 •  **MUTATION**:  = "MUTATION"
 
-*Defined in [constants.ts:81](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L81)*
+*Defined in [constants.ts:82](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L82)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 •  **NONE**:  = "NONE"
 
-*Defined in [constants.ts:83](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L83)*
+*Defined in [constants.ts:84](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L84)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **QUERY**:  = "QUERY"
 
-*Defined in [constants.ts:80](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L80)*
+*Defined in [constants.ts:81](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L81)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 •  **SUBSCRIPTION**:  = "SUBSCRIPTION"
 
-*Defined in [constants.ts:82](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L82)*
+*Defined in [constants.ts:83](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L83)*

--- a/docs/enums/graphrefinputtype.md
+++ b/docs/enums/graphrefinputtype.md
@@ -23,7 +23,7 @@ function graph implementation.
 
 •  **ARGUMENT**:  = "ARGUMENT"
 
-*Defined in [constants.ts:112](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L112)*
+*Defined in [constants.ts:113](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L113)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **FUNCTION\_RESULT**:  = "FUNCTION\_RESULT"
 
-*Defined in [constants.ts:113](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L113)*
+*Defined in [constants.ts:114](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L114)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **OPERATION\_ARGUMENT**:  = "OPERATION\_ARGUMENT"
 
-*Defined in [constants.ts:114](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L114)*
+*Defined in [constants.ts:115](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L115)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 •  **OPERATION\_RESULT**:  = "OPERATION\_RESULT"
 
-*Defined in [constants.ts:115](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L115)*
+*Defined in [constants.ts:116](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L116)*
 
 ___
 
@@ -55,4 +55,4 @@ ___
 
 •  **OUTPUT\_ARGUMENT\_REF**:  = "OUTPUT\_ARGUMENT\_REF"
 
-*Defined in [constants.ts:116](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L116)*
+*Defined in [constants.ts:117](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L117)*

--- a/docs/enums/implementationtype.md
+++ b/docs/enums/implementationtype.md
@@ -18,4 +18,4 @@ The different types implementations that can be used on a CKG function.
 
 •  **FUNCTION\_GRAPH**:  = "FUNCTION\_GRAPH"
 
-*Defined in [constants.ts:90](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L90)*
+*Defined in [constants.ts:91](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L91)*

--- a/docs/enums/maanaerrorcode.md
+++ b/docs/enums/maanaerrorcode.md
@@ -27,7 +27,7 @@ coming through the Assistant API.
 
 •  **DATA\_NOT\_FOUND**:  = 102
 
-*Defined in [constants.ts:128](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L128)*
+*Defined in [constants.ts:129](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L129)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 •  **GRAPHQL**:  = 103
 
-*Defined in [constants.ts:129](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L129)*
+*Defined in [constants.ts:130](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L130)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 •  **INVALID\_PARAMS**:  = 101
 
-*Defined in [constants.ts:127](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L127)*
+*Defined in [constants.ts:128](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L128)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 •  **MISSING\_PARAMS**:  = 100
 
-*Defined in [constants.ts:126](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L126)*
+*Defined in [constants.ts:127](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L127)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 •  **NOT\_IMPLEMENTED**:  = 104
 
-*Defined in [constants.ts:130](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L130)*
+*Defined in [constants.ts:131](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L131)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 •  **PERMISSION**:  = 105
 
-*Defined in [constants.ts:131](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L131)*
+*Defined in [constants.ts:132](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L132)*
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 •  **UNKNOWN\_ERROR**:  = 0
 
-*Defined in [constants.ts:124](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L124)*
+*Defined in [constants.ts:125](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L125)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 •  **UNKNOWN\_GRAPHQL\_ERROR**:  = 1
 
-*Defined in [constants.ts:125](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L125)*
+*Defined in [constants.ts:126](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L126)*
 
 ___
 
@@ -91,4 +91,4 @@ ___
 
 •  **VERSION**:  = 106
 
-*Defined in [constants.ts:132](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L132)*
+*Defined in [constants.ts:133](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L133)*

--- a/docs/enums/nodetype.md
+++ b/docs/enums/nodetype.md
@@ -25,7 +25,7 @@ OPERATION nodes are used to add functions onto the function graph.
 
 •  **ARGUMENT**:  = "ARGUMENT"
 
-*Defined in [constants.ts:102](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L102)*
+*Defined in [constants.ts:103](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L103)*
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 •  **ENTITY**:  = "ENTITY"
 
-*Defined in [constants.ts:103](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L103)*
+*Defined in [constants.ts:104](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L104)*
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 •  **OPERATION**:  = "OPERATION"
 
-*Defined in [constants.ts:104](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L104)*
+*Defined in [constants.ts:105](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L105)*

--- a/docs/enums/servicetype.md
+++ b/docs/enums/servicetype.md
@@ -21,7 +21,7 @@ The different types of possible services
 
 •  **ASSISTANT**:  = "AssistantService"
 
-*Defined in [constants.ts:62](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L62)*
+*Defined in [constants.ts:63](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L63)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 •  **EXTERNAL\_GRAPHQL**:  = "ExternalGraphQLService"
 
-*Defined in [constants.ts:63](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L63)*
+*Defined in [constants.ts:64](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L64)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **LOGIC**:  = "LogicService"
 
-*Defined in [constants.ts:64](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L64)*
+*Defined in [constants.ts:65](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L65)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 •  **MODEL**:  = "ModelService"
 
-*Defined in [constants.ts:65](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L65)*
+*Defined in [constants.ts:66](https://github.com/maana-io/q-assistant-client/blob/develop/src/constants.ts#L66)*

--- a/docs/interfaces/annotation.md
+++ b/docs/interfaces/annotation.md
@@ -1,0 +1,59 @@
+**[Maana Q Assistant API Client](../README.md)**
+
+> [Globals](../README.md) / Annotation
+
+# Interface: Annotation
+
+## Hierarchy
+
+* **Annotation**
+
+## Index
+
+### Properties
+
+* [description](annotation.md#description)
+* [id](annotation.md#id)
+* [name](annotation.md#name)
+* [nameDescriptor](annotation.md#namedescriptor)
+* [workspaceId](annotation.md#workspaceid)
+
+## Properties
+
+### description
+
+• `Optional` **description**: string
+
+*Defined in [models.ts:89](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L89)*
+
+___
+
+### id
+
+•  **id**: string
+
+*Defined in [models.ts:86](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L86)*
+
+___
+
+### name
+
+•  **name**: string
+
+*Defined in [models.ts:87](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L87)*
+
+___
+
+### nameDescriptor
+
+• `Optional` **nameDescriptor**: string
+
+*Defined in [models.ts:88](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L88)*
+
+___
+
+### workspaceId
+
+• `Optional` **workspaceId**: string
+
+*Defined in [models.ts:90](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L90)*

--- a/docs/interfaces/argumentfieldselection.md
+++ b/docs/interfaces/argumentfieldselection.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:278](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L278)*
+*Defined in [models.ts:286](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L286)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **fieldSelection**: string[][]
 
-*Defined in [models.ts:279](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L279)*
+*Defined in [models.ts:287](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L287)*

--- a/docs/interfaces/argumentfieldselectioninput.md
+++ b/docs/interfaces/argumentfieldselectioninput.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:727](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L727)*
+*Defined in [models.ts:747](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L747)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • `Optional` **fieldSelection**: [Maybe](../README.md#maybe)\<Array\<Array\<string>>>
 
-*Defined in [models.ts:728](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L728)*
+*Defined in [models.ts:748](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L748)*

--- a/docs/interfaces/argumentref.md
+++ b/docs/interfaces/argumentref.md
@@ -21,7 +21,7 @@
 
 •  **argumentId**: string
 
-*Defined in [models.ts:87](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L87)*
+*Defined in [models.ts:95](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L95)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **argumentName**: string
 
-*Defined in [models.ts:86](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L86)*
+*Defined in [models.ts:94](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L94)*

--- a/docs/interfaces/assistant.md
+++ b/docs/interfaces/assistant.md
@@ -55,7 +55,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:413](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L413)*
+*Defined in [models.ts:421](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L421)*
 
 The location that the Assistant can be reached at.
 
@@ -89,7 +89,7 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:419](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L419)*
+*Defined in [models.ts:427](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L427)*
 
 The current version of the Assistant.  This is incremented by catalog each
 time the Assistant is updated.
@@ -100,7 +100,7 @@ time the Assistant is updated.
 
 ▸ **update**(`changes`: [UpdateAssistantInput](updateassistantinput.md)): Promise\<void>
 
-*Defined in [models.ts:425](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L425)*
+*Defined in [models.ts:433](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L433)*
 
 Updates information about the Assistant.
 

--- a/docs/interfaces/cloneentityinput.md
+++ b/docs/interfaces/cloneentityinput.md
@@ -23,7 +23,7 @@
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:766](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L766)*
+*Defined in [models.ts:787](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L787)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **newName**: string
 
-*Defined in [models.ts:769](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L769)*
+*Defined in [models.ts:790](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L790)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **oldName**: string
 
-*Defined in [models.ts:767](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L767)*
+*Defined in [models.ts:788](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L788)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **oldServiceId**: string
 
-*Defined in [models.ts:768](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L768)*
+*Defined in [models.ts:789](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L789)*

--- a/docs/interfaces/connection.md
+++ b/docs/interfaces/connection.md
@@ -22,7 +22,7 @@
 
 •  **from**: [GraphRef](../README.md#graphref)
 
-*Defined in [models.ts:123](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L123)*
+*Defined in [models.ts:131](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L131)*
 
 End point for the outgoing connection point
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:120](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L120)*
+*Defined in [models.ts:128](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L128)*
 
 ___
 
@@ -40,6 +40,6 @@ ___
 
 •  **to**: [GraphRef](../README.md#graphref)
 
-*Defined in [models.ts:126](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L126)*
+*Defined in [models.ts:134](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L134)*
 
 End point for the incoming connection point

--- a/docs/interfaces/createannotationinput.md
+++ b/docs/interfaces/createannotationinput.md
@@ -1,0 +1,41 @@
+**[Maana Q Assistant API Client](../README.md)**
+
+> [Globals](../README.md) / CreateAnnotationInput
+
+# Interface: CreateAnnotationInput
+
+## Hierarchy
+
+* **CreateAnnotationInput**
+
+## Index
+
+### Properties
+
+* [description](createannotationinput.md#description)
+* [id](createannotationinput.md#id)
+* [name](createannotationinput.md#name)
+
+## Properties
+
+### description
+
+• `Optional` **description**: [Maybe](../README.md#maybe)\<string>
+
+*Defined in [models.ts:743](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L743)*
+
+___
+
+### id
+
+• `Optional` **id**: [Maybe](../README.md#maybe)\<string>
+
+*Defined in [models.ts:741](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L741)*
+
+___
+
+### name
+
+•  **name**: string
+
+*Defined in [models.ts:742](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L742)*

--- a/docs/interfaces/createconnectioninput.md
+++ b/docs/interfaces/createconnectioninput.md
@@ -21,7 +21,7 @@
 
 •  **from**: [GraphRefInput](graphrefinput.md)
 
-*Defined in [models.ts:700](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L700)*
+*Defined in [models.ts:714](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L714)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **to**: [GraphRefInput](graphrefinput.md)
 
-*Defined in [models.ts:701](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L701)*
+*Defined in [models.ts:715](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L715)*

--- a/docs/interfaces/createentityinput.md
+++ b/docs/interfaces/createentityinput.md
@@ -12,6 +12,7 @@
 
 ### Properties
 
+* [annotation](createentityinput.md#annotation)
 * [entityType](createentityinput.md#entitytype)
 * [file](createentityinput.md#file)
 * [function](createentityinput.md#function)
@@ -20,11 +21,19 @@
 
 ## Properties
 
+### annotation
+
+• `Optional` **annotation**: [Maybe](../README.md#maybe)\<[CreateAnnotationInput](createannotationinput.md)>
+
+*Defined in [models.ts:783](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L783)*
+
+___
+
 ### entityType
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:758](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L758)*
+*Defined in [models.ts:778](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L778)*
 
 ___
 
@@ -32,7 +41,7 @@ ___
 
 • `Optional` **file**: [Maybe](../README.md#maybe)\<[CreateFileInput](createfileinput.md)>
 
-*Defined in [models.ts:762](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L762)*
+*Defined in [models.ts:782](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L782)*
 
 ___
 
@@ -40,7 +49,7 @@ ___
 
 • `Optional` **function**: [Maybe](../README.md#maybe)\<[CreateFunctionInput](createfunctioninput.md)>
 
-*Defined in [models.ts:761](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L761)*
+*Defined in [models.ts:781](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L781)*
 
 ___
 
@@ -48,7 +57,7 @@ ___
 
 • `Optional` **knowledgeGraph**: [Maybe](../README.md#maybe)\<[CreateKnowledgeGraphInput](createknowledgegraphinput.md)>
 
-*Defined in [models.ts:759](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L759)*
+*Defined in [models.ts:779](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L779)*
 
 ___
 
@@ -56,4 +65,4 @@ ___
 
 • `Optional` **type**: [Maybe](../README.md#maybe)\<[CreateTypeInput](createtypeinput.md)>
 
-*Defined in [models.ts:760](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L760)*
+*Defined in [models.ts:780](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L780)*

--- a/docs/interfaces/createfileinput.md
+++ b/docs/interfaces/createfileinput.md
@@ -30,7 +30,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:746](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L746)*
+*Defined in [models.ts:766](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L766)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:744](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L744)*
+*Defined in [models.ts:764](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L764)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • `Optional` **loadExternalMetadata**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:754](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L754)*
+*Defined in [models.ts:774](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L774)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • `Optional` **mimeType**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:750](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L750)*
+*Defined in [models.ts:770](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L770)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:745](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L745)*
+*Defined in [models.ts:765](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L765)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • `Optional` **progress**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:752](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L752)*
+*Defined in [models.ts:772](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L772)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 •  **serviceId**: string
 
-*Defined in [models.ts:747](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L747)*
+*Defined in [models.ts:767](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L767)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • `Optional` **size**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:751](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L751)*
+*Defined in [models.ts:771](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L771)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • `Optional` **status**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:753](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L753)*
+*Defined in [models.ts:773](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L773)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:749](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L749)*
+*Defined in [models.ts:769](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L769)*
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 •  **url**: string
 
-*Defined in [models.ts:748](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L748)*
+*Defined in [models.ts:768](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L768)*

--- a/docs/interfaces/createfunctioninput.md
+++ b/docs/interfaces/createfunctioninput.md
@@ -28,7 +28,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:734](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L734)*
+*Defined in [models.ts:754](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L754)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • `Optional` **graphImplementation**: [Maybe](../README.md#maybe)\<[CreateGraphInput](creategraphinput.md)>
 
-*Defined in [models.ts:739](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L739)*
+*Defined in [models.ts:759](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L759)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 •  **graphqlFunctionType**: [GraphQLFunctionType](../enums/graphqlfunctiontype.md)
 
-*Defined in [models.ts:737](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L737)*
+*Defined in [models.ts:757](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L757)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:732](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L732)*
+*Defined in [models.ts:752](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L752)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 •  **implementation**: [ImplementationType](../enums/implementationtype.md)
 
-*Defined in [models.ts:738](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L738)*
+*Defined in [models.ts:758](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L758)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • `Optional` **inputMask**: [Maybe](../README.md#maybe)\<Array\<[ArgumentFieldSelectionInput](argumentfieldselectioninput.md)>>
 
-*Defined in [models.ts:740](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L740)*
+*Defined in [models.ts:760](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L760)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • `Optional` **isPure**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:736](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L736)*
+*Defined in [models.ts:756](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L756)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:733](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L733)*
+*Defined in [models.ts:753](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L753)*
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:735](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L735)*
+*Defined in [models.ts:755](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L755)*

--- a/docs/interfaces/creategraphinput.md
+++ b/docs/interfaces/creategraphinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **connections**: [Maybe](../README.md#maybe)\<Array\<[CreateConnectionInput](createconnectioninput.md)>>
 
-*Defined in [models.ts:708](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L708)*
+*Defined in [models.ts:722](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L722)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **nodes**: [Maybe](../README.md#maybe)\<Array\<[CreateNodeInput](createnodeinput.md)>>
 
-*Defined in [models.ts:707](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L707)*
+*Defined in [models.ts:721](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L721)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **offset**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:705](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L705)*
+*Defined in [models.ts:719](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L719)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **zoom**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:706](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L706)*
+*Defined in [models.ts:720](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L720)*

--- a/docs/interfaces/createknowledgegraphinput.md
+++ b/docs/interfaces/createknowledgegraphinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:714](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L714)*
+*Defined in [models.ts:728](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L728)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **graph**: [Maybe](../README.md#maybe)\<[CreateGraphInput](creategraphinput.md)>
 
-*Defined in [models.ts:715](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L715)*
+*Defined in [models.ts:729](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L729)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:712](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L712)*
+*Defined in [models.ts:726](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L726)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:713](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L713)*
+*Defined in [models.ts:727](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L727)*

--- a/docs/interfaces/createnodeinput.md
+++ b/docs/interfaces/createnodeinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:674](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L674)*
+*Defined in [models.ts:688](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L688)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Optional` **entity**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:676](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L676)*
+*Defined in [models.ts:690](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L690)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:671](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L671)*
+*Defined in [models.ts:685](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L685)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isCollapsed**: [Maybe](../README.md#maybe)\<string[]>
 
-*Defined in [models.ts:673](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L673)*
+*Defined in [models.ts:687](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L687)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:672](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L672)*
+*Defined in [models.ts:686](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L686)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **operation**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:677](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L677)*
+*Defined in [models.ts:691](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L691)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:675](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L675)*
+*Defined in [models.ts:689](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L689)*

--- a/docs/interfaces/createserviceinput.md
+++ b/docs/interfaces/createserviceinput.md
@@ -28,7 +28,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:653](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L653)*
+*Defined in [models.ts:667](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L667)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 •  **endpointUrl**: string
 
-*Defined in [models.ts:654](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L654)*
+*Defined in [models.ts:668](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L668)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:650](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L650)*
+*Defined in [models.ts:664](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L664)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • `Optional` **isReadOnly**: boolean
 
-*Defined in [models.ts:657](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L657)*
+*Defined in [models.ts:671](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L671)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • `Optional` **isSystem**: boolean
 
-*Defined in [models.ts:656](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L656)*
+*Defined in [models.ts:670](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L670)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:652](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L652)*
+*Defined in [models.ts:666](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L666)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 •  **serviceType**: [ServiceType](../enums/servicetype.md)
 
-*Defined in [models.ts:651](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L651)*
+*Defined in [models.ts:665](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L665)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • `Optional` **tags**: Array\<string>
 
-*Defined in [models.ts:658](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L658)*
+*Defined in [models.ts:672](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L672)*
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:655](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L655)*
+*Defined in [models.ts:669](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L669)*

--- a/docs/interfaces/createtypeinput.md
+++ b/docs/interfaces/createtypeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:721](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L721)*
+*Defined in [models.ts:735](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L735)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:719](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L719)*
+*Defined in [models.ts:733](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L733)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isManaged**: boolean
 
-*Defined in [models.ts:723](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L723)*
+*Defined in [models.ts:737](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L737)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:720](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L720)*
+*Defined in [models.ts:734](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L734)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:722](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L722)*
+*Defined in [models.ts:736](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L736)*

--- a/docs/interfaces/createworkspaceinput.md
+++ b/docs/interfaces/createworkspaceinput.md
@@ -31,7 +31,7 @@
 
 • `Optional` **addServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:851](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L851)*
+*Defined in [models.ts:879](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L879)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **createEntities**: [Maybe](../README.md#maybe)\<Array\<[CreateEntityInput](createentityinput.md)>>
 
-*Defined in [models.ts:850](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L850)*
+*Defined in [models.ts:878](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L878)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:844](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L844)*
+*Defined in [models.ts:872](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L872)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • `Optional` **id**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:841](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L841)*
+*Defined in [models.ts:869](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L869)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 • `Optional` **isPublic**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:848](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L848)*
+*Defined in [models.ts:876](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L876)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 • `Optional` **isTemplate**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:849](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L849)*
+*Defined in [models.ts:877](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L877)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 • `Optional` **moveEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:857](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L857)*
+*Defined in [models.ts:885](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L885)*
 
 Moves the given entities from their current Workspace to this one.
 Currently only Types and Functions support being moved between Workspaces.
@@ -90,7 +90,7 @@ ___
 
 •  **name**: string
 
-*Defined in [models.ts:843](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L843)*
+*Defined in [models.ts:871](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L871)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 •  **owner**: string
 
-*Defined in [models.ts:847](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L847)*
+*Defined in [models.ts:875](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L875)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • `Optional` **serviceId**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:842](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L842)*
+*Defined in [models.ts:870](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L870)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:846](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L846)*
+*Defined in [models.ts:874](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L874)*
 
 ___
 
@@ -122,4 +122,4 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:845](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L845)*
+*Defined in [models.ts:873](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L873)*

--- a/docs/interfaces/entitylockinput.md
+++ b/docs/interfaces/entitylockinput.md
@@ -20,4 +20,4 @@
 
 •  **lockedBy**: string
 
-*Defined in [models.ts:662](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L662)*
+*Defined in [models.ts:676](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L676)*

--- a/docs/interfaces/function.md
+++ b/docs/interfaces/function.md
@@ -62,7 +62,7 @@ ___
 
 •  **graphqlFunctionType**: [GraphQLFunctionType](../enums/graphqlfunctiontype.md)
 
-*Defined in [models.ts:301](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L301)*
+*Defined in [models.ts:309](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L309)*
 
 How the function is run (like query or mutation)
 
@@ -84,7 +84,7 @@ ___
 
 •  **implementation**: [Implementation](../README.md#implementation)
 
-*Defined in [models.ts:312](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L312)*
+*Defined in [models.ts:320](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L320)*
 
 The implementation representing what the Function does.  This is only used
 by Functions on Logic services.
@@ -95,7 +95,7 @@ ___
 
 • `Optional` **inputMask**: [ArgumentFieldSelection](argumentfieldselection.md)[]
 
-*Defined in [models.ts:314](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L314)*
+*Defined in [models.ts:322](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L322)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 •  **isPure**: boolean
 
-*Defined in [models.ts:306](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L306)*
+*Defined in [models.ts:314](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L314)*
 
 Defines if this is a pure or impure Function, or if its purity is unknown.
 
@@ -137,7 +137,7 @@ ___
 
 •  **service**: [IDObject](idobject.md)
 
-*Defined in [models.ts:295](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L295)*
+*Defined in [models.ts:303](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L303)*
 
 The service that the Kind comes from.
 
@@ -147,7 +147,7 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:292](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L292)*
+*Defined in [models.ts:300](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L300)*
 
 The signature of the Function.
 
@@ -157,7 +157,7 @@ ___
 
 •  **typeParameters**: string[]
 
-*Defined in [models.ts:298](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L298)*
+*Defined in [models.ts:306](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L306)*
 
 Type Parameters are placeholders for types and are used as generics.
 
@@ -167,7 +167,7 @@ Type Parameters are placeholders for types and are used as generics.
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:319](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L319)*
+*Defined in [models.ts:327](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L327)*
 
 Returns boolean stating if the Function is editable.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **execute**(`variables?`: [Maybe](../README.md#maybe)\<Record\<string, any>>, `resolve?`: string): Promise\<any>
 
-*Defined in [models.ts:361](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L361)*
+*Defined in [models.ts:369](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L369)*
 
 Executes a GraphQL request against the Function.
 
@@ -200,7 +200,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:324](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L324)*
+*Defined in [models.ts:332](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L332)*
 
 Returns the e-mail of the user who locked the Function.
 
@@ -212,7 +212,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:331](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L331)*
+*Defined in [models.ts:339](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L339)*
 
 Updates the locked state of the Function.
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)): Promise\<void>
 
-*Defined in [models.ts:337](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L337)*
+*Defined in [models.ts:345](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L345)*
 
 Updates information about the Function.
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **updateGraphLayout**(`changes`: [UpdateGraphLayoutInput](updategraphlayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:353](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L353)*
+*Defined in [models.ts:361](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L361)*
 
 Updates the layout information for the graph of the Function.
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **updateNodeLayout**(`nodeId`: string, `changes`: [UpdateNodeLayoutInput](updatenodelayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:344](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L344)*
+*Defined in [models.ts:352](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L352)*
 
 Updates the layout information for a node in the Function.
 

--- a/docs/interfaces/functionresultref.md
+++ b/docs/interfaces/functionresultref.md
@@ -20,4 +20,4 @@
 
 • `Optional` **result**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:97](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L97)*
+*Defined in [models.ts:105](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L105)*

--- a/docs/interfaces/graph.md
+++ b/docs/interfaces/graph.md
@@ -23,7 +23,7 @@
 
 •  **connections**: [Connection](connection.md)[]
 
-*Defined in [models.ts:165](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L165)*
+*Defined in [models.ts:173](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L173)*
 
 The connections in the Graph.
 
@@ -33,7 +33,7 @@ ___
 
 •  **nodes**: [Node](node.md)[]
 
-*Defined in [models.ts:162](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L162)*
+*Defined in [models.ts:170](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L170)*
 
 The nodes in the Graph.
 
@@ -43,7 +43,7 @@ ___
 
 •  **offset**: [Position](position.md)
 
-*Defined in [models.ts:156](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L156)*
+*Defined in [models.ts:164](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L164)*
 
 The offset of the Graph.
 
@@ -53,6 +53,6 @@ ___
 
 •  **zoom**: number
 
-*Defined in [models.ts:159](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L159)*
+*Defined in [models.ts:167](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L167)*
 
 The zoom of the Graph.

--- a/docs/interfaces/graphrefinput.md
+++ b/docs/interfaces/graphrefinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **argument**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:693](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L693)*
+*Defined in [models.ts:707](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L707)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **graphRefInputType**: [GraphRefInputType](../enums/graphrefinputtype.md)
 
-*Defined in [models.ts:692](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L692)*
+*Defined in [models.ts:706](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L706)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **operationArgument**: [Maybe](../README.md#maybe)\<[OperationArgumentRefInput](operationargumentrefinput.md)>
 
-*Defined in [models.ts:694](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L694)*
+*Defined in [models.ts:708](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L708)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **operationResult**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:695](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L695)*
+*Defined in [models.ts:709](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L709)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **outputArgument**: [Maybe](../README.md#maybe)\<[OutputArgumentRefInput](outputargumentrefinput.md)>
 
-*Defined in [models.ts:696](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L696)*
+*Defined in [models.ts:710](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L710)*

--- a/docs/interfaces/inventorychanged.md
+++ b/docs/interfaces/inventorychanged.md
@@ -22,7 +22,7 @@ The information returned from an inventory changed event.
 
 •  **diff**: { functions: { adds: [Maybe](../README.md#maybe)\<[Function](function.md)[]> ; deletes: [Maybe](../README.md#maybe)\<[Function](function.md)[]> ; updates: [Maybe](../README.md#maybe)\<[Function](function.md)[]>  } ; kinds: { adds: [Maybe](../README.md#maybe)\<[Kind](kind.md)[]> ; deletes: [Maybe](../README.md#maybe)\<[Kind](kind.md)[]> ; updates: [Maybe](../README.md#maybe)\<[Kind](kind.md)[]>  } ; services: { adds: [Maybe](../README.md#maybe)\<[Service](service.md)[]> ; deletes: [Maybe](../README.md#maybe)\<[Service](service.md)[]> ; updates: [Maybe](../README.md#maybe)\<[Service](service.md)[]>  }  }
 
-*Defined in [models.ts:886](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L886)*
+*Defined in [models.ts:914](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L914)*
 
 #### Type declaration:
 

--- a/docs/interfaces/kind.md
+++ b/docs/interfaces/kind.md
@@ -56,7 +56,7 @@ ___
 
 •  **isManaged**: boolean
 
-*Defined in [models.ts:176](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L176)*
+*Defined in [models.ts:184](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L184)*
 
 Used to signify if this type has data that is managed by the platform
 
@@ -90,7 +90,7 @@ ___
 
 •  **service**: [IDObject](idobject.md)
 
-*Defined in [models.ts:173](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L173)*
+*Defined in [models.ts:181](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L181)*
 
 The service that the Kind comes from.
 
@@ -100,7 +100,7 @@ ___
 
 •  **signature**: [TypeExpressionObject](../README.md#typeexpressionobject)
 
-*Defined in [models.ts:170](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L170)*
+*Defined in [models.ts:178](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L178)*
 
 The signature of the Kind.
 
@@ -110,7 +110,7 @@ The signature of the Kind.
 
 ▸ **update**(`changes`: [UpdateTypeInput](updatetypeinput.md)): Promise\<void>
 
-*Defined in [models.ts:182](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L182)*
+*Defined in [models.ts:190](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L190)*
 
 Updates information about the Kind.
 

--- a/docs/interfaces/knowledgegraph.md
+++ b/docs/interfaces/knowledgegraph.md
@@ -65,7 +65,7 @@ ___
 
 •  **graph**: [Graph](graph.md)
 
-*Defined in [models.ts:215](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L215)*
+*Defined in [models.ts:223](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L223)*
 
 The graph information for the Knowledge Graph.
 
@@ -111,7 +111,7 @@ ___
 
 •  **offsetX**: number
 
-*Defined in [models.ts:200](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L200)*
+*Defined in [models.ts:208](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L208)*
 
 The X offset of the Knowledge Graph.
 
@@ -123,7 +123,7 @@ ___
 
 •  **offsetY**: number
 
-*Defined in [models.ts:206](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L206)*
+*Defined in [models.ts:214](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L214)*
 
 The Y offset of the Knowledge Graph.
 
@@ -135,7 +135,7 @@ ___
 
 •  **zoom**: number
 
-*Defined in [models.ts:212](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L212)*
+*Defined in [models.ts:220](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L220)*
 
 The zoom of the Knowledge Graph.
 
@@ -147,7 +147,7 @@ The zoom of the Knowledge Graph.
 
 ▸ **addNode**(`entityIdentifier`: [EntityIdentifier](entityidentifier.md)): Promise\<string>
 
-*Defined in [models.ts:246](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L246)*
+*Defined in [models.ts:254](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L254)*
 
 Adds an entity as a node on the Knowledge Graph.
 
@@ -167,7 +167,7 @@ ___
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:218](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L218)*
+*Defined in [models.ts:226](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L226)*
 
 Returns boolean stating if the Knowledge Graph is editable.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **getNodes**(): Promise\<[Node](node.md)[]>
 
-*Defined in [models.ts:240](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L240)*
+*Defined in [models.ts:248](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L248)*
 
 Returns the list of nodes inside of the Knowledge Graph.
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:221](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L221)*
+*Defined in [models.ts:229](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L229)*
 
 Returns the e-mail of the user who locked the Knowledge Graph.
 
@@ -205,7 +205,7 @@ ___
 
 ▸ **removeNode**(`nodeId`: string): Promise\<void>
 
-*Defined in [models.ts:253](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L253)*
+*Defined in [models.ts:261](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L261)*
 
 Removed a node from the Knowledge Graph.
 
@@ -225,7 +225,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:228](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L228)*
+*Defined in [models.ts:236](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L236)*
 
 Updates the locked state of the Knowledge Graph.
 
@@ -243,7 +243,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateKnowledgeGraphInput](updateknowledgegraphinput.md)): Promise\<void>
 
-*Defined in [models.ts:234](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L234)*
+*Defined in [models.ts:242](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L242)*
 
 Updates information about the Knowledge Graph.
 
@@ -261,7 +261,7 @@ ___
 
 ▸ **updateGraphLayout**(`changes`: [UpdateGraphLayoutInput](updategraphlayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:269](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L269)*
+*Defined in [models.ts:277](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L277)*
 
 Updates the layout information for the graph of the Knowledge Graph.
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **updateNodeLayout**(`nodeId`: string, `changes`: [UpdateNodeLayoutInput](updatenodelayoutinput.md)): Promise\<void>
 
-*Defined in [models.ts:260](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L260)*
+*Defined in [models.ts:268](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L268)*
 
 Updates the layout information for a node in the Knowledge Graph.
 

--- a/docs/interfaces/lockchangeditem.md
+++ b/docs/interfaces/lockchangeditem.md
@@ -23,7 +23,7 @@ Information about an entity that had its locked state changed.
 
 •  **id**: string
 
-*Defined in [models.ts:907](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L907)*
+*Defined in [models.ts:935](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L935)*
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 •  **lock**: [Maybe](../README.md#maybe)\<{ email: string ; id: string  }>
 
-*Defined in [models.ts:908](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L908)*
+*Defined in [models.ts:936](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L936)*

--- a/docs/interfaces/lockingchanged.md
+++ b/docs/interfaces/lockingchanged.md
@@ -24,7 +24,7 @@ The information returned from an locking changed event.
 
 •  **functions**: [Maybe](../README.md#maybe)\<[LockChangedItem](lockchangeditem.md)[]>
 
-*Defined in [models.ts:918](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L918)*
+*Defined in [models.ts:946](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L946)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **knowledgeGraphs**: [Maybe](../README.md#maybe)\<[LockChangedItem](lockchangeditem.md)[]>
 
-*Defined in [models.ts:917](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L917)*
+*Defined in [models.ts:945](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L945)*
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 •  **workspaces**: [Maybe](../README.md#maybe)\<[LockChangedItem](lockchangeditem.md)[]>
 
-*Defined in [models.ts:916](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L916)*
+*Defined in [models.ts:944](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L944)*

--- a/docs/interfaces/node.md
+++ b/docs/interfaces/node.md
@@ -27,7 +27,7 @@ The core shape of a node
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:136](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L136)*
+*Defined in [models.ts:144](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L144)*
 
 Human readable description of the Node.
 
@@ -37,7 +37,7 @@ ___
 
 • `Optional` **entityIdentifier**: [Maybe](../README.md#maybe)\<[EntityIdentifier](entityidentifier.md)>
 
-*Defined in [models.ts:151](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L151)*
+*Defined in [models.ts:159](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L159)*
 
 The entity referenced by the node.
 
@@ -47,7 +47,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:133](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L133)*
+*Defined in [models.ts:141](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L141)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 •  **isCollapsed**: string[]
 
-*Defined in [models.ts:145](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L145)*
+*Defined in [models.ts:153](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L153)*
 
 List of identifiers to signify different collapsed areas in the node.
 
@@ -65,7 +65,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[Position](position.md)>
 
-*Defined in [models.ts:142](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L142)*
+*Defined in [models.ts:150](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L150)*
 
 Position of the node on the graph. Null indicates the need to layout the
 position.
@@ -76,6 +76,6 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:148](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L148)*
+*Defined in [models.ts:156](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L156)*
 
 The type of node

--- a/docs/interfaces/operationargumentref.md
+++ b/docs/interfaces/operationargumentref.md
@@ -22,7 +22,7 @@
 
 •  **argumentId**: string
 
-*Defined in [models.ts:93](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L93)*
+*Defined in [models.ts:101](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L101)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **argumentName**: string
 
-*Defined in [models.ts:92](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L92)*
+*Defined in [models.ts:100](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L100)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operationId**: string
 
-*Defined in [models.ts:91](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L91)*
+*Defined in [models.ts:99](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L99)*

--- a/docs/interfaces/operationargumentrefinput.md
+++ b/docs/interfaces/operationargumentrefinput.md
@@ -21,7 +21,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:682](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L682)*
+*Defined in [models.ts:696](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L696)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:681](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L681)*
+*Defined in [models.ts:695](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L695)*

--- a/docs/interfaces/operationresultref.md
+++ b/docs/interfaces/operationresultref.md
@@ -20,4 +20,4 @@
 
 •  **operationId**: string
 
-*Defined in [models.ts:101](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L101)*
+*Defined in [models.ts:109](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L109)*

--- a/docs/interfaces/outputargumentref.md
+++ b/docs/interfaces/outputargumentref.md
@@ -22,7 +22,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:107](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L107)*
+*Defined in [models.ts:115](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L115)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **fieldPath**: string[]
 
-*Defined in [models.ts:106](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L106)*
+*Defined in [models.ts:114](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L114)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:105](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L105)*
+*Defined in [models.ts:113](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L113)*

--- a/docs/interfaces/outputargumentrefinput.md
+++ b/docs/interfaces/outputargumentrefinput.md
@@ -22,7 +22,7 @@
 
 •  **argument**: string
 
-*Defined in [models.ts:688](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L688)*
+*Defined in [models.ts:702](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L702)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 •  **fieldPath**: Array\<string>
 
-*Defined in [models.ts:687](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L687)*
+*Defined in [models.ts:701](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L701)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 •  **operation**: string
 
-*Defined in [models.ts:686](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L686)*
+*Defined in [models.ts:700](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L700)*

--- a/docs/interfaces/positioninput.md
+++ b/docs/interfaces/positioninput.md
@@ -21,7 +21,7 @@
 
 • `Optional` **x**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:666](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L666)*
+*Defined in [models.ts:680](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L680)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • `Optional` **y**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:667](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L667)*
+*Defined in [models.ts:681](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L681)*

--- a/docs/interfaces/service.md
+++ b/docs/interfaces/service.md
@@ -59,7 +59,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:380](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L380)*
+*Defined in [models.ts:388](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L388)*
 
 The location that the service can be reached at.
 
@@ -93,7 +93,7 @@ ___
 
 •  **type**: [ServiceType](../enums/servicetype.md)
 
-*Defined in [models.ts:389](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L389)*
+*Defined in [models.ts:397](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L397)*
 
 The type of the service.
 
@@ -103,7 +103,7 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:386](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L386)*
+*Defined in [models.ts:394](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L394)*
 
 The current version of the Service.  This is incremented by catalog each
 time the service is updated.
@@ -114,7 +114,7 @@ time the service is updated.
 
 ▸ **getFunctions**(): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:395](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L395)*
+*Defined in [models.ts:403](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L403)*
 
 Retrieves the list of Function that are part of the Service.
 
@@ -126,7 +126,7 @@ ___
 
 ▸ **getKinds**(): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:392](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L392)*
+*Defined in [models.ts:400](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L400)*
 
 Retrieves the list of Kinds that are part of the Service.
 
@@ -138,7 +138,7 @@ ___
 
 ▸ **getWorkspace**(): Promise\<[Maybe](../README.md#maybe)\<[Workspace](workspace.md)>>
 
-*Defined in [models.ts:402](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L402)*
+*Defined in [models.ts:410](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L410)*
 
 Loads the Workspace that is connected with the service. Only works for for
 Logic services. If there is no workspace connected with the service then
@@ -152,7 +152,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateExternalGraphQLServiceInput](updateexternalgraphqlserviceinput.md)): Promise\<void>
 
-*Defined in [models.ts:408](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L408)*
+*Defined in [models.ts:416](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L416)*
 
 Updates information about the Service.
 

--- a/docs/interfaces/servicelocation.md
+++ b/docs/interfaces/servicelocation.md
@@ -21,7 +21,7 @@
 
 •  **platformUrl**: string
 
-*Defined in [models.ts:375](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L375)*
+*Defined in [models.ts:383](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L383)*
 
 A form of the URL that uses the Maana Q platform to proxy a request to the
 service. This is useful if the client cannot directly access the service.
@@ -32,6 +32,6 @@ ___
 
 •  **url**: string
 
-*Defined in [models.ts:369](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L369)*
+*Defined in [models.ts:377](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L377)*
 
 The URL that the locator references.

--- a/docs/interfaces/updateannotationinput.md
+++ b/docs/interfaces/updateannotationinput.md
@@ -1,0 +1,41 @@
+**[Maana Q Assistant API Client](../README.md)**
+
+> [Globals](../README.md) / UpdateAnnotationInput
+
+# Interface: UpdateAnnotationInput
+
+## Hierarchy
+
+* **UpdateAnnotationInput**
+
+## Index
+
+### Properties
+
+* [description](updateannotationinput.md#description)
+* [id](updateannotationinput.md#id)
+* [name](updateannotationinput.md#name)
+
+## Properties
+
+### description
+
+• `Optional` **description**: [Maybe](../README.md#maybe)\<string>
+
+*Defined in [models.ts:830](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L830)*
+
+___
+
+### id
+
+•  **id**: string
+
+*Defined in [models.ts:828](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L828)*
+
+___
+
+### name
+
+• `Optional` **name**: [Maybe](../README.md#maybe)\<string>
+
+*Defined in [models.ts:829](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L829)*

--- a/docs/interfaces/updateassistantinput.md
+++ b/docs/interfaces/updateassistantinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **endpointUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:642](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L642)*
+*Defined in [models.ts:656](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L656)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:640](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L640)*
+*Defined in [models.ts:654](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L654)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **isReadOnly**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:644](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L644)*
+*Defined in [models.ts:658](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L658)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isSystem**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:643](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L643)*
+*Defined in [models.ts:657](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L657)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:641](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L641)*
+*Defined in [models.ts:655](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L655)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:645](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L645)*
+*Defined in [models.ts:659](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L659)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:646](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L646)*
+*Defined in [models.ts:660](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L660)*

--- a/docs/interfaces/updateentityinput.md
+++ b/docs/interfaces/updateentityinput.md
@@ -12,6 +12,7 @@
 
 ### Properties
 
+* [annotation](updateentityinput.md#annotation)
 * [entityType](updateentityinput.md#entitytype)
 * [file](updateentityinput.md#file)
 * [function](updateentityinput.md#function)
@@ -20,11 +21,19 @@
 
 ## Properties
 
+### annotation
+
+• `Optional` **annotation**: [Maybe](../README.md#maybe)\<[UpdateAnnotationInput](updateannotationinput.md)>
+
+*Defined in [models.ts:865](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L865)*
+
+___
+
 ### entityType
 
 •  **entityType**: [EntityType](../enums/entitytype.md)
 
-*Defined in [models.ts:833](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L833)*
+*Defined in [models.ts:860](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L860)*
 
 ___
 
@@ -32,7 +41,7 @@ ___
 
 • `Optional` **file**: [Maybe](../README.md#maybe)\<[UpdateFileInput](updatefileinput.md)>
 
-*Defined in [models.ts:837](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L837)*
+*Defined in [models.ts:864](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L864)*
 
 ___
 
@@ -40,7 +49,7 @@ ___
 
 • `Optional` **function**: [Maybe](../README.md#maybe)\<[UpdateFunctionInput](updatefunctioninput.md)>
 
-*Defined in [models.ts:836](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L836)*
+*Defined in [models.ts:863](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L863)*
 
 ___
 
@@ -48,7 +57,7 @@ ___
 
 • `Optional` **knowledgeGraph**: [Maybe](../README.md#maybe)\<[UpdateKnowledgeGraphInput](updateknowledgegraphinput.md)>
 
-*Defined in [models.ts:834](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L834)*
+*Defined in [models.ts:861](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L861)*
 
 ___
 
@@ -56,4 +65,4 @@ ___
 
 • `Optional` **type**: [Maybe](../README.md#maybe)\<[UpdateTypeInput](updatetypeinput.md)>
 
-*Defined in [models.ts:835](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L835)*
+*Defined in [models.ts:862](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L862)*

--- a/docs/interfaces/updateexternalgraphqlserviceinput.md
+++ b/docs/interfaces/updateexternalgraphqlserviceinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **endpointUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:632](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L632)*
+*Defined in [models.ts:646](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L646)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:630](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L630)*
+*Defined in [models.ts:644](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L644)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **isReadOnly**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:634](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L634)*
+*Defined in [models.ts:648](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L648)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **isSystem**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:633](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L633)*
+*Defined in [models.ts:647](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L647)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:631](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L631)*
+*Defined in [models.ts:645](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L645)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:635](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L635)*
+*Defined in [models.ts:649](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L649)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 •  **version**: number
 
-*Defined in [models.ts:636](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L636)*
+*Defined in [models.ts:650](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L650)*

--- a/docs/interfaces/updatefileinput.md
+++ b/docs/interfaces/updatefileinput.md
@@ -29,7 +29,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:822](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L822)*
+*Defined in [models.ts:849](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L849)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:820](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L820)*
+*Defined in [models.ts:847](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L847)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • `Optional` **mimeType**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:826](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L826)*
+*Defined in [models.ts:853](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L853)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:821](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L821)*
+*Defined in [models.ts:848](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L848)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • `Optional` **progress**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:828](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L828)*
+*Defined in [models.ts:855](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L855)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • `Optional` **serviceId**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:823](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L823)*
+*Defined in [models.ts:850](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L850)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • `Optional` **size**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:827](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L827)*
+*Defined in [models.ts:854](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L854)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • `Optional` **status**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:829](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L829)*
+*Defined in [models.ts:856](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L856)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:825](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L825)*
+*Defined in [models.ts:852](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L852)*
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • `Optional` **url**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:824](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L824)*
+*Defined in [models.ts:851](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L851)*

--- a/docs/interfaces/updatefunctioninput.md
+++ b/docs/interfaces/updatefunctioninput.md
@@ -29,7 +29,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:809](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L809)*
+*Defined in [models.ts:836](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L836)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • `Optional` **graphImplementation**: [Maybe](../README.md#maybe)\<[UpdateGraphInput](updategraphinput.md)>
 
-*Defined in [models.ts:815](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L815)*
+*Defined in [models.ts:842](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L842)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • `Optional` **graphqlFunctionType**: [Maybe](../README.md#maybe)\<[GraphQLFunctionType](../enums/graphqlfunctiontype.md)>
 
-*Defined in [models.ts:812](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L812)*
+*Defined in [models.ts:839](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L839)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:807](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L807)*
+*Defined in [models.ts:834](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L834)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • `Optional` **implementation**: [Maybe](../README.md#maybe)\<[ImplementationType](../enums/implementationtype.md)>
 
-*Defined in [models.ts:814](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L814)*
+*Defined in [models.ts:841](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L841)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • `Optional` **inputMask**: [Maybe](../README.md#maybe)\<Array\<[ArgumentFieldSelectionInput](argumentfieldselectioninput.md)>>
 
-*Defined in [models.ts:816](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L816)*
+*Defined in [models.ts:843](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L843)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • `Optional` **isPure**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:811](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L811)*
+*Defined in [models.ts:838](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L838)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:813](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L813)*
+*Defined in [models.ts:840](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L840)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:808](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L808)*
+*Defined in [models.ts:835](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L835)*
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 • `Optional` **signature**: [Maybe](../README.md#maybe)\<[TypeExpressionObject](../README.md#typeexpressionobject)>
 
-*Defined in [models.ts:810](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L810)*
+*Defined in [models.ts:837](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L837)*

--- a/docs/interfaces/updategraphinput.md
+++ b/docs/interfaces/updategraphinput.md
@@ -26,7 +26,7 @@
 
 • `Optional` **createConnections**: [Maybe](../README.md#maybe)\<Array\<[CreateConnectionInput](createconnectioninput.md)>>
 
-*Defined in [models.ts:786](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L786)*
+*Defined in [models.ts:807](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L807)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Optional` **createNodes**: [Maybe](../README.md#maybe)\<Array\<[CreateNodeInput](createnodeinput.md)>>
 
-*Defined in [models.ts:783](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L783)*
+*Defined in [models.ts:804](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L804)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **deleteConnections**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:787](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L787)*
+*Defined in [models.ts:808](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L808)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **deleteNodes**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:785](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L785)*
+*Defined in [models.ts:806](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L806)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **offset**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:781](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L781)*
+*Defined in [models.ts:802](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L802)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **updateNodes**: [Maybe](../README.md#maybe)\<Array\<[UpdateNodeInput](updatenodeinput.md)>>
 
-*Defined in [models.ts:784](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L784)*
+*Defined in [models.ts:805](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L805)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 • `Optional` **zoom**: [Maybe](../README.md#maybe)\<number>
 
-*Defined in [models.ts:782](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L782)*
+*Defined in [models.ts:803](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L803)*

--- a/docs/interfaces/updategraphlayoutinput.md
+++ b/docs/interfaces/updategraphlayoutinput.md
@@ -23,7 +23,7 @@
 
 • `Optional` **nodes**: [UpdateNodeLayoutInput](updatenodelayoutinput.md) & { id: string  }[]
 
-*Defined in [models.ts:626](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L626)*
+*Defined in [models.ts:640](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L640)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • `Optional` **offsetX**: number
 
-*Defined in [models.ts:624](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L624)*
+*Defined in [models.ts:638](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L638)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **offsetY**: number
 
-*Defined in [models.ts:625](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L625)*
+*Defined in [models.ts:639](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L639)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **zoom**: number
 
-*Defined in [models.ts:623](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L623)*
+*Defined in [models.ts:637](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L637)*

--- a/docs/interfaces/updateknowledgegraphinput.md
+++ b/docs/interfaces/updateknowledgegraphinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:793](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L793)*
+*Defined in [models.ts:814](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L814)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • `Optional` **graph**: [Maybe](../README.md#maybe)\<[UpdateGraphInput](updategraphinput.md)>
 
-*Defined in [models.ts:795](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L795)*
+*Defined in [models.ts:816](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L816)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:791](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L791)*
+*Defined in [models.ts:812](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L812)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:794](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L794)*
+*Defined in [models.ts:815](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L815)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:792](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L792)*
+*Defined in [models.ts:813](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L813)*

--- a/docs/interfaces/updatenodeinput.md
+++ b/docs/interfaces/updatenodeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:776](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L776)*
+*Defined in [models.ts:797](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L797)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:773](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L773)*
+*Defined in [models.ts:794](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L794)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isCollapsed**: [Maybe](../README.md#maybe)\<string[]>
 
-*Defined in [models.ts:775](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L775)*
+*Defined in [models.ts:796](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L796)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **location**: [Maybe](../README.md#maybe)\<[PositionInput](positioninput.md)>
 
-*Defined in [models.ts:774](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L774)*
+*Defined in [models.ts:795](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L795)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 •  **type**: [NodeType](../enums/nodetype.md)
 
-*Defined in [models.ts:777](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L777)*
+*Defined in [models.ts:798](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L798)*

--- a/docs/interfaces/updatenodelayoutinput.md
+++ b/docs/interfaces/updatenodelayoutinput.md
@@ -22,7 +22,7 @@
 
 • `Optional` **isCollapsed**: string[]
 
-*Defined in [models.ts:619](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L619)*
+*Defined in [models.ts:633](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L633)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • `Optional` **x**: number
 
-*Defined in [models.ts:617](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L617)*
+*Defined in [models.ts:631](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L631)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • `Optional` **y**: number
 
-*Defined in [models.ts:618](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L618)*
+*Defined in [models.ts:632](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L632)*

--- a/docs/interfaces/updatetypeinput.md
+++ b/docs/interfaces/updatetypeinput.md
@@ -24,7 +24,7 @@
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:801](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L801)*
+*Defined in [models.ts:822](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L822)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:799](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L799)*
+*Defined in [models.ts:820](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L820)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **isManaged**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:803](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L803)*
+*Defined in [models.ts:824](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L824)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:800](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L800)*
+*Defined in [models.ts:821](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L821)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • `Optional` **signature**: [Maybe](../README.md#maybe)\<[TypeExpressionObject](../README.md#typeexpressionobject)>
 
-*Defined in [models.ts:802](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L802)*
+*Defined in [models.ts:823](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L823)*

--- a/docs/interfaces/updateworkspaceinput.md
+++ b/docs/interfaces/updateworkspaceinput.md
@@ -34,7 +34,7 @@
 
 • `Optional` **addServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:880](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L880)*
+*Defined in [models.ts:908](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L908)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • `Optional` **cloneEntities**: [Maybe](../README.md#maybe)\<Array\<[CloneEntityInput](cloneentityinput.md)>>
 
-*Defined in [models.ts:870](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L870)*
+*Defined in [models.ts:898](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L898)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **createEntities**: [Maybe](../README.md#maybe)\<Array\<[CreateEntityInput](createentityinput.md)>>
 
-*Defined in [models.ts:869](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L869)*
+*Defined in [models.ts:897](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L897)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • `Optional` **deleteEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:879](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L879)*
+*Defined in [models.ts:907](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L907)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • `Optional` **description**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:863](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L863)*
+*Defined in [models.ts:891](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L891)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 •  **id**: string
 
-*Defined in [models.ts:861](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L861)*
+*Defined in [models.ts:889](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L889)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • `Optional` **isPublic**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:866](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L866)*
+*Defined in [models.ts:894](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L894)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 • `Optional` **isTemplate**: [Maybe](../README.md#maybe)\<boolean>
 
-*Defined in [models.ts:867](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L867)*
+*Defined in [models.ts:895](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L895)*
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 • `Optional` **lock**: [Maybe](../README.md#maybe)\<[EntityLockInput](entitylockinput.md)>
 
-*Defined in [models.ts:868](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L868)*
+*Defined in [models.ts:896](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L896)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 • `Optional` **moveEntities**: [Maybe](../README.md#maybe)\<Array\<[EntityIdentifier](entityidentifier.md)>>
 
-*Defined in [models.ts:877](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L877)*
+*Defined in [models.ts:905](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L905)*
 
 Moves the given entities from their current Workspace to this one.
 Currently only Types and Functions support being moved between Workspaces.
@@ -117,7 +117,7 @@ ___
 
 • `Optional` **name**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:862](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L862)*
+*Defined in [models.ts:890](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L890)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 • `Optional` **removeServices**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:881](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L881)*
+*Defined in [models.ts:909](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L909)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 • `Optional` **tags**: [Maybe](../README.md#maybe)\<Array\<string>>
 
-*Defined in [models.ts:865](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L865)*
+*Defined in [models.ts:893](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L893)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 • `Optional` **thumbnailUrl**: [Maybe](../README.md#maybe)\<string>
 
-*Defined in [models.ts:864](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L864)*
+*Defined in [models.ts:892](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L892)*
 
 ___
 
@@ -149,4 +149,4 @@ ___
 
 • `Optional` **updateEntities**: [Maybe](../README.md#maybe)\<Array\<[UpdateEntityInput](updateentityinput.md)>>
 
-*Defined in [models.ts:871](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L871)*
+*Defined in [models.ts:899](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L899)*

--- a/docs/interfaces/workspace.md
+++ b/docs/interfaces/workspace.md
@@ -39,6 +39,8 @@
 * [deleteFunction](workspace.md#deletefunction)
 * [deleteKind](workspace.md#deletekind)
 * [getActiveGraph](workspace.md#getactivegraph)
+* [getAnnotationById](workspace.md#getannotationbyid)
+* [getAnnotations](workspace.md#getannotations)
 * [getFunctionGraph](workspace.md#getfunctiongraph)
 * [getFunctions](workspace.md#getfunctions)
 * [getFunctionsByName](workspace.md#getfunctionsbyname)
@@ -91,7 +93,7 @@ ___
 
 •  **isPublic**: boolean
 
-*Defined in [models.ts:442](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L442)*
+*Defined in [models.ts:450](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L450)*
 
 When true others can see this Workspace.
 
@@ -101,7 +103,7 @@ ___
 
 •  **isTemplate**: boolean
 
-*Defined in [models.ts:445](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L445)*
+*Defined in [models.ts:453](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L453)*
 
 When true it shows up as a template Workspace.
 
@@ -111,7 +113,7 @@ ___
 
 •  **location**: [ServiceLocation](servicelocation.md)
 
-*Defined in [models.ts:430](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L430)*
+*Defined in [models.ts:438](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L438)*
 
 The location information about the Workspace.
 
@@ -145,7 +147,7 @@ ___
 
 •  **owner**: { id: string ; name: string  }
 
-*Defined in [models.ts:451](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L451)*
+*Defined in [models.ts:459](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L459)*
 
 The user that owns the Workspace.
 
@@ -162,7 +164,7 @@ ___
 
 •  **persistenceServiceId**: string
 
-*Defined in [models.ts:439](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L439)*
+*Defined in [models.ts:447](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L447)*
 
 The ID of the model service handling persistence for the Workspace
 
@@ -172,7 +174,7 @@ ___
 
 •  **serviceId**: string
 
-*Defined in [models.ts:436](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L436)*
+*Defined in [models.ts:444](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L444)*
 
 The ID of the logic service backing the Workspace.
 
@@ -182,7 +184,7 @@ ___
 
 •  **tags**: string[]
 
-*Defined in [models.ts:448](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L448)*
+*Defined in [models.ts:456](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L456)*
 
 The list of tags for the Workspace.
 
@@ -192,7 +194,7 @@ ___
 
 •  **thumbnailUrl**: string
 
-*Defined in [models.ts:433](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L433)*
+*Defined in [models.ts:441](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L441)*
 
 The URL to the URL of the thumbnail pic.
 
@@ -202,7 +204,7 @@ The URL to the URL of the thumbnail pic.
 
 ▸ **canEdit**(): Promise\<boolean>
 
-*Defined in [models.ts:454](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L454)*
+*Defined in [models.ts:462](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L462)*
 
 Returns boolean stating if the Workspace is editable.
 
@@ -214,7 +216,7 @@ ___
 
 ▸ **createFunction**(`input`: [CreateFunctionInput](createfunctioninput.md)): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:541](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L541)*
+*Defined in [models.ts:549](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L549)*
 
 Creates a new Function in the Workspace.
 
@@ -232,7 +234,7 @@ ___
 
 ▸ **createFunctions**(`input`: [CreateFunctionInput](createfunctioninput.md)[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:547](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L547)*
+*Defined in [models.ts:555](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L555)*
 
 Creates a list of new Functions in the Workspace.
 
@@ -250,7 +252,7 @@ ___
 
 ▸ **createKind**(`input`: [CreateTypeInput](createtypeinput.md)): Promise\<[Kind](kind.md)>
 
-*Defined in [models.ts:589](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L589)*
+*Defined in [models.ts:597](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L597)*
 
 Creates a new Kind in the Workspace.
 
@@ -268,7 +270,7 @@ ___
 
 ▸ **createKinds**(`input`: [CreateTypeInput](createtypeinput.md)[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:595](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L595)*
+*Defined in [models.ts:603](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L603)*
 
 Creates a list of Kinds in the Workspace.
 
@@ -286,7 +288,7 @@ ___
 
 ▸ **createKnowledgeGraph**(`input`: [CreateKnowledgeGraphInput](createknowledgegraphinput.md)): Promise\<void>
 
-*Defined in [models.ts:488](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L488)*
+*Defined in [models.ts:496](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L496)*
 
 Creates a new Knowledge Graph in the Workspace.
 
@@ -304,7 +306,7 @@ ___
 
 ▸ **createKnowledgeGraphs**(`input`: [CreateKnowledgeGraphInput](createknowledgegraphinput.md)[]): Promise\<void>
 
-*Defined in [models.ts:494](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L494)*
+*Defined in [models.ts:502](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L502)*
 
 Creates a list of new Knowledge Graphs in the Workspace.
 
@@ -322,7 +324,7 @@ ___
 
 ▸ **deleteFunction**(`name`: string): Promise\<void>
 
-*Defined in [models.ts:565](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L565)*
+*Defined in [models.ts:573](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L573)*
 
 Deletes a function in the Workspace.
 
@@ -340,7 +342,7 @@ ___
 
 ▸ **deleteKind**(`name`: string): Promise\<void>
 
-*Defined in [models.ts:613](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L613)*
+*Defined in [models.ts:627](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L627)*
 
 Deletes a Kind in the Workspace.
 
@@ -358,7 +360,7 @@ ___
 
 ▸ **getActiveGraph**(): Promise\<[Maybe](../README.md#maybe)\<[KnowledgeGraph](knowledgegraph.md) \| [Function](function.md)>>
 
-*Defined in [models.ts:479](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L479)*
+*Defined in [models.ts:487](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L487)*
 
 Gets the currently active graph.
 
@@ -366,11 +368,41 @@ Gets the currently active graph.
 
 ___
 
+### getAnnotationById
+
+▸ **getAnnotationById**(`id`: string): Promise\<[Maybe](../README.md#maybe)\<[Annotation](annotation.md)>>
+
+*Defined in [models.ts:621](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L621)*
+
+Gets an Annotation in the Workspace by ID
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** Promise\<[Maybe](../README.md#maybe)\<[Annotation](annotation.md)>>
+
+___
+
+### getAnnotations
+
+▸ **getAnnotations**(): Promise\<[Annotation](annotation.md)[]>
+
+*Defined in [models.ts:618](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L618)*
+
+Gets the list of Annotations that live in the Workspace
+
+**Returns:** Promise\<[Annotation](annotation.md)[]>
+
+___
+
 ### getFunctionGraph
 
 ▸ **getFunctionGraph**(`id`: string): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:574](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L574)*
+*Defined in [models.ts:582](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L582)*
 
 Gets the Function based on ID with its implementation and graph
 information.
@@ -392,7 +424,7 @@ ___
 
 ▸ **getFunctions**(): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:529](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L529)*
+*Defined in [models.ts:537](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L537)*
 
 Gets the list of Functions that live in the Workspace.
 
@@ -404,7 +436,7 @@ ___
 
 ▸ **getFunctionsByName**(`names`: string[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:535](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L535)*
+*Defined in [models.ts:543](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L543)*
 
 Gets a list of Functions that live in the Workspace based on their names.
 
@@ -422,7 +454,7 @@ ___
 
 ▸ **getImportedAssistants**(): Promise\<[Assistant](assistant.md)[]>
 
-*Defined in [models.ts:500](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L500)*
+*Defined in [models.ts:508](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L508)*
 
 Gets all of the Assistants imported into the Workspaces inventory.
 
@@ -434,7 +466,7 @@ ___
 
 ▸ **getImportedServices**(): Promise\<[Service](service.md)[]>
 
-*Defined in [models.ts:497](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L497)*
+*Defined in [models.ts:505](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L505)*
 
 Gets all of the Services imported into the Workspaces inventory.
 
@@ -446,7 +478,7 @@ ___
 
 ▸ **getKinds**(): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:577](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L577)*
+*Defined in [models.ts:585](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L585)*
 
 Gets the list of Kinds that live in the Workspace.
 
@@ -458,7 +490,7 @@ ___
 
 ▸ **getKindsByName**(`names`: string[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:583](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L583)*
+*Defined in [models.ts:591](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L591)*
 
 Gets a list of Kinds that live in the Workspace based on their names.
 
@@ -476,7 +508,7 @@ ___
 
 ▸ **getKnowledgeGraphs**(): Promise\<[KnowledgeGraph](knowledgegraph.md)[]>
 
-*Defined in [models.ts:482](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L482)*
+*Defined in [models.ts:490](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L490)*
 
 Gets all of the Knowledge Graphs in the Workspace.
 
@@ -488,7 +520,7 @@ ___
 
 ▸ **importService**(`serviceId`: string): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:507](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L507)*
+*Defined in [models.ts:515](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L515)*
 
 Imports a Service or Assistant into the Workspaces inventory.
 
@@ -508,7 +540,7 @@ ___
 
 ▸ **importServices**(`serviceIds`: string[]): Promise\<string[]>
 
-*Defined in [models.ts:514](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L514)*
+*Defined in [models.ts:522](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L522)*
 
 Imports a list of Services and/or Assistants into the Workspaces inventory.
 
@@ -528,7 +560,7 @@ ___
 
 ▸ **lockedBy**(): Promise\<[Maybe](../README.md#maybe)\<string>>
 
-*Defined in [models.ts:457](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L457)*
+*Defined in [models.ts:465](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L465)*
 
 Returns the e-mail of the user who locked the Workspace.
 
@@ -540,7 +572,7 @@ ___
 
 ▸ **reload**(): Promise\<[Workspace](workspace.md)>
 
-*Defined in [models.ts:473](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L473)*
+*Defined in [models.ts:481](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L481)*
 
 Returns a new copy of the workspace with reloaded information.
 
@@ -552,7 +584,7 @@ ___
 
 ▸ **removeService**(`serviceId`: string): Promise\<void>
 
-*Defined in [models.ts:520](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L520)*
+*Defined in [models.ts:528](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L528)*
 
 Removes a Service or Assistant from the Workspaces inventory.
 
@@ -570,7 +602,7 @@ ___
 
 ▸ **removeServices**(`serviceIds`: string): Promise\<void>
 
-*Defined in [models.ts:526](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L526)*
+*Defined in [models.ts:534](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L534)*
 
 Removes a list Services and/or Assistants from the Workspaces inventory.
 
@@ -588,7 +620,7 @@ ___
 
 ▸ **setLocked**(`isLocked?`: boolean): Promise\<void>
 
-*Defined in [models.ts:464](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L464)*
+*Defined in [models.ts:472](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L472)*
 
 Updates the locked state of the Workspace.
 
@@ -606,7 +638,7 @@ ___
 
 ▸ **triggerRepairEvent**(): Promise\<void>
 
-*Defined in [models.ts:476](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L476)*
+*Defined in [models.ts:484](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L484)*
 
 Sends a repair event to all assistants.
 
@@ -618,7 +650,7 @@ ___
 
 ▸ **update**(`changes`: [UpdateWorkspaceInput](updateworkspaceinput.md)): Promise\<void>
 
-*Defined in [models.ts:470](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L470)*
+*Defined in [models.ts:478](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L478)*
 
 Updates information about the Workspace.
 
@@ -636,7 +668,7 @@ ___
 
 ▸ **updateFunction**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)): Promise\<[Function](function.md)>
 
-*Defined in [models.ts:553](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L553)*
+*Defined in [models.ts:561](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L561)*
 
 Updates a Function in the Workspace.
 
@@ -654,7 +686,7 @@ ___
 
 ▸ **updateFunctions**(`changes`: [UpdateFunctionInput](updatefunctioninput.md)[]): Promise\<[Function](function.md)[]>
 
-*Defined in [models.ts:559](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L559)*
+*Defined in [models.ts:567](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L567)*
 
 Updates a list of Function in the Workspace.
 
@@ -672,7 +704,7 @@ ___
 
 ▸ **updateKind**(`changes`: [UpdateTypeInput](updatetypeinput.md)): Promise\<[Kind](kind.md)>
 
-*Defined in [models.ts:601](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L601)*
+*Defined in [models.ts:609](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L609)*
 
 Updates a Kind in the Workspace.
 
@@ -690,7 +722,7 @@ ___
 
 ▸ **updateKinds**(`changes`: [UpdateTypeInput](updatetypeinput.md)[]): Promise\<[Kind](kind.md)[]>
 
-*Defined in [models.ts:607](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L607)*
+*Defined in [models.ts:615](https://github.com/maana-io/q-assistant-client/blob/develop/src/models.ts#L615)*
 
 Updates a list of Kinds in the Workspace.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.3.0-beta.17",
+  "version": "3.3.0-beta.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.3.0-beta.17",
+  "version": "3.3.0-beta.18",
   "description": "JavaScript package to streamline communication between an assistant and the Maana Q Assistant API.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,7 @@ export enum Scalars {
  * from selection or used in graph nodes.
  */
 export enum EntityType {
+  ANNOTATION = 'ANNOTATION',
   FILE = 'FILE',
   FUNCTION = 'FUNCTION',
   KNOWLEDGE_GRAPH = 'KNOWLEDGE_GRAPH',

--- a/src/models.ts
+++ b/src/models.ts
@@ -82,6 +82,14 @@ export interface Entity {
   description?: string;
 }
 
+export interface Annotation {
+  id: string;
+  name: string;
+  nameDescriptor?: string;
+  description?: string;
+  workspaceId?: string;
+}
+
 export interface ArgumentRef {
   argumentName: string;
   argumentId: string;
@@ -606,6 +614,12 @@ export interface Workspace extends Entity {
    */
   updateKinds(changes: UpdateTypeInput[]): Promise<Kind[]>;
 
+  /** Gets the list of Annotations that live in the Workspace */
+  getAnnotations(): Promise<Annotation[]>;
+
+  /** Gets an Annotation in the Workspace by ID */
+  getAnnotationById(id: string): Promise<Maybe<Annotation>>;
+
   /**
    * Deletes a Kind in the Workspace.
    * @param name The name of the Kind to delete.
@@ -723,6 +737,12 @@ export interface CreateTypeInput {
   isManaged?: boolean;
 }
 
+export interface CreateAnnotationInput {
+  id?: Maybe<string>;
+  name: string;
+  description?: Maybe<string>;
+}
+
 export interface ArgumentFieldSelectionInput {
   argument: string;
   fieldSelection?: Maybe<Array<Array<string>>>;
@@ -760,6 +780,7 @@ export interface CreateEntityInput {
   type?: Maybe<CreateTypeInput>;
   function?: Maybe<CreateFunctionInput>;
   file?: Maybe<CreateFileInput>;
+  annotation?: Maybe<CreateAnnotationInput>;
 }
 
 export interface CloneEntityInput {
@@ -803,6 +824,12 @@ export interface UpdateTypeInput {
   isManaged?: Maybe<boolean>;
 }
 
+export interface UpdateAnnotationInput {
+  id: string;
+  name?: Maybe<string>;
+  description?: Maybe<string>;
+}
+
 export interface UpdateFunctionInput {
   id: string;
   name?: Maybe<string>;
@@ -835,6 +862,7 @@ export interface UpdateEntityInput {
   type?: Maybe<UpdateTypeInput>;
   function?: Maybe<UpdateFunctionInput>;
   file?: Maybe<UpdateFileInput>;
+  annotation?: Maybe<UpdateAnnotationInput>;
 }
 
 export interface CreateWorkspaceInput {


### PR DESCRIPTION
https://maanainc.atlassian.net/browse/QP-2712

* Be able to get all assistants in a workspace, or get an assistant in a workspace by ID.
* Add models for Annotation, CreateAnnotationInput, and UpdateAnnotationInput.
* Create, Update, and Delete are already handled by the generic `update` function on the workspace.

![Screen Shot 2021-06-25 at 2 11 55 PM](https://user-images.githubusercontent.com/950818/123486050-3126de00-d5c0-11eb-8e0f-b13fc190a99e.png)
