### PR TITLE
🐛  QP-3443: v3.2.4-beta.40: fix bad path in `exports` field of package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.2.4-beta",
+  "version": "3.2.4-beta.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JavaScript package to streamline communication between an assistant and the Maana Q Assistant API.",
   "main": "build/index.js",
   "exports": {
-    ".": "./build/"
+    ".": "./build"
   },
   "scripts": {
     "build": "babel src --out-dir build",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@io-maana/q-assistant-client",
-  "version": "3.2.4-beta",
+  "version": "3.2.4-beta.40",
   "description": "JavaScript package to streamline communication between an assistant and the Maana Q Assistant API.",
   "main": "build/index.js",
   "exports": {
-    "./": "./build/"
+    ".": "./build/"
   },
   "scripts": {
     "build": "babel src --out-dir build",


### PR DESCRIPTION
The formatting of the path used in the `exports` field in `package.json` was poorly formatted and causing build issues in the Bayes assistant.

Documentation: https://nodejs.org/api/packages.html#subpath-exports

Ticket: https://maanainc.atlassian.net/browse/QP-3443